### PR TITLE
Bump libsodium to 1.10021.0

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "noise-c",
-    "version": "0.1.10",
+    "version": "0.1.11",
     "description": "noise-c",
     "keywords": "noise-c",
     "repository": {
@@ -20,7 +20,7 @@
         {
             "owner": "esphome",
             "name": "libsodium",
-            "version": "1.10020.7"
+            "version": "1.10021.0"
         }
     ]
 }


### PR DESCRIPTION
## Summary

- Bump libsodium dependency from 1.10020.7 to 1.10021.0
- Bump noise-c version to 0.1.11

## Changes in libsodium 1.10021.0

- Update libsodium submodule to 1.0.21-RELEASE
- Optimize poly1305 and chacha20 with aligned loads for Xtensa/RISC-V (10-24% faster encryption)
- Fix ChaCha20-Poly1305 AEAD source path