### PR TITLE
Bump version to 0.1.12 and fix libsodium dependency for IDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Noise-C Library
 ===============
 
-**Note**: This is a port of the [noise-c](https://github.com/rweather/noise-c) library to support 1. PlatformIO build system and 2. ESP8266/ESP32 targets.
+**Note**: This is a port of the [noise-c](https://github.com/rweather/noise-c) library to support 1. the [PlatformIO](https://platformio.org/) and [ESP-IDF](https://github.com/espressif/esp-idf) build systems and 2. ESP8266/ESP32 targets.
 
 Noise-C is a plain C implementation of the
 [Noise Protocol](http://noiseprotocol.org), intended as a

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,5 +1,5 @@
 description: noise-c
-version: 0.1.11
+version: 0.1.12
 repository: https://github.com/esphome/noise-c.git
 dependencies:
-  esphome/libsodium: "1.10021.0"
+  esphome/libsodium: "1.10021.1"

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "noise-c",
-    "version": "0.1.11",
+    "version": "0.1.12",
     "description": "noise-c",
     "keywords": "noise-c",
     "repository": {
@@ -20,7 +20,7 @@
         {
             "owner": "esphome",
             "name": "libsodium",
-            "version": "1.10021.0"
+            "version": "1.10021.1"
         }
     ]
 }


### PR DESCRIPTION
Bumps noise-c to `0.1.12` so a release can be cut to publish the component to the [ESP-IDF component registry](https://components.espressif.com/) (the `publish-espressif` job added in #11 has never run because no release postdates it).

## Changes
- Bump version `0.1.11` → `0.1.12` in `idf_component.yml` and `library.json`.
- Update the `esphome/libsodium` dependency `1.10021.0` → `1.10021.1` in both manifests.
- README: mention ESP-IDF as a supported build system (mirrors esphome-libs/libsodium).

## Why the dependency bump is required
The IDF registry only has libsodium `1.10021.1` published; noise-c pinned the exact version `1.10021.0`, which is not on the registry. Without this bump, a published noise-c would fail dependency resolution on ESP-IDF. `1.10021.1` is also published on PlatformIO, so the `library.json` change is safe.

After merge, cutting release **v0.1.12** triggers the publish workflow (PlatformIO + Espressif).