### PR TITLE
Add LICENSE file and bump to 0.1.13

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (C) 2016 Southern Storm Software, Pty Ltd.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,5 +1,5 @@
 description: noise-c
-version: 0.1.12
+version: 0.1.13
 repository: https://github.com/esphome/noise-c.git
 dependencies:
   esphome/libsodium: "1.10021.1"

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "noise-c",
-    "version": "0.1.12",
+    "version": "0.1.13",
     "description": "noise-c",
     "keywords": "noise-c",
     "repository": {


### PR DESCRIPTION
The v0.1.12 release published to PlatformIO but **failed on the ESP-IDF registry**: `A valid license file or license field in the manifest could not be found`. The registry auto-detects a `LICENSE` file (or a `license:` manifest field), but noise-c's license file is named `COPYING`, which it doesn't recognize.

## Changes
- Add a `LICENSE` file (copy of `COPYING`, which contains the verbatim MIT License text) so the registry detects it — same approach as esphome-libs/libsodium.
- Bump version `0.1.12` → `0.1.13` in `idf_component.yml` and `library.json` (0.1.12 can't be re-published).

`COPYING` is kept for the autotools build convention. After merge, cutting release **v0.1.13** publishes to both PlatformIO and the ESP-IDF registry.