### PR TITLE
Add generic CMake target for non-ESP-IDF consumers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
-idf_component_register(
-  SRCS
+set(NOISE_C_SRCS
   "src/backend/openssl/cipher-aesgcm.c"
   "src/backend/ref/cipher-aesgcm.c"
   "src/backend/ref/cipher-chachapoly.c"
@@ -36,9 +35,29 @@ idf_component_register(
   "src/protocol/signstate.c"
   "src/protocol/symmetricstate.c"
   "src/protocol/util.c"
-  INCLUDE_DIRS
-  "include"
-  "src"
-  REQUIRES
-  esphome__libsodium
 )
+
+if(ESP_PLATFORM)
+  idf_component_register(
+    SRCS ${NOISE_C_SRCS}
+    INCLUDE_DIRS "include" "src"
+    REQUIRES esphome__libsodium
+  )
+else()
+  cmake_minimum_required(VERSION 3.13)
+
+  add_library(noise_c STATIC ${NOISE_C_SRCS})
+  add_library(esphome::noise_c ALIAS noise_c)
+
+  target_include_directories(noise_c PUBLIC
+    "${CMAKE_CURRENT_LIST_DIR}/include"
+    "${CMAKE_CURRENT_LIST_DIR}/src"
+  )
+
+  # backend is a compile-time choice made by the consumer via the NOISE_USE_*
+  # macros in include/noise/defines.h; the default backend is libsodium, so
+  # link a libsodium target if the consumer has already defined one.
+  if(TARGET sodium)
+    target_link_libraries(noise_c PUBLIC sodium)
+  endif()
+endif()


### PR DESCRIPTION
## What

Outside ESP-IDF the `CMakeLists.txt` did nothing useful: it was a bare `idf_component_register()` call, so a plain CMake project could not consume this library at all. This adds an `else()` branch that defines a normal static library target `noise_c`, plus an `esphome::noise_c` alias, so any CMake project can `add_subdirectory()` this repo and link the target by name.

The motivating consumer is ESPHome's upcoming bare Raspberry Pi pico-sdk build for RP2040/RP2350. pico-sdk projects are ordinary CMake, and ESPHome currently has to synthesise a CMakeLists for each PlatformIO library it pulls in by reading `library.json` and globbing sources. Shipping a real target here lets it just link `esphome::noise_c` instead.

## How

The curated source list moves into a single `NOISE_C_SRCS` variable consumed by both branches, so the ESP-IDF component and the generic target cannot drift apart. That is the main maintenance win.

Backend selection remains a compile-time choice made by the consumer through the `NOISE_USE_*` macros in `include/noise/defines.h`, exactly as before. The generic branch opportunistically links a `sodium` target if the consumer has already defined one, since the default backend is libsodium.

## Compatibility

Neither existing consumer changes behaviour:

- **ESP-IDF**: the `idf_component_register()` call receives byte-identical arguments. Verified by stubbing `idf_component_register`, dumping the expanded argument vector on both `esp-port` and this branch, and diffing them: identical, 42 arguments.
- **PlatformIO**: `library.json` is untouched and no source file was added, removed, moved or reordered. PlatformIO ignores `CMakeLists.txt` entirely, so esp32-arduino, esp8266, rp2-arduino and libretiny are unaffected.

`cmake_minimum_required(VERSION 3.13)` is scoped inside the generic branch so the ESP-IDF path's policy scope is untouched, and there is no `project()` call since the parent project owns language enablement.

## Verification

A throwaway consumer project using `add_subdirectory()` was built two ways. On the host with the default libsodium backend it configures, compiles, links and runs, successfully constructing a `Noise_NNpsk0_25519_ChaChaPoly_SHA256` handshake. Cross-compiled with `arm-none-eabi-gcc` for Cortex-M0+ using the reference backend (`NOISE_USE_REFERENCE_BACKEND=1 NOISE_USE_LIBSODIUM=0`) it produces a 20,497 byte `libnoise_c.a`.