### PR TITLE
Merge upstream rweather/noise-c master

### DIFF
--- a/include/noise/Makefile.am
+++ b/include/noise/Makefile.am
@@ -1,6 +1,7 @@
 
 noiseincludedir = $(includedir)/noise
 noiseinclude_HEADERS = \
+    keys.h \
     protocol.h \
     protobufs.h
 

--- a/src/protocol/Makefile.am
+++ b/src/protocol/Makefile.am
@@ -69,7 +69,8 @@ libnoiseprotocol_a_SOURCES += \
 else !USE_OPENSSL
 if USE_LIBSODIUM
 libnoiseprotocol_a_SOURCES += \
-	../backend/sodium/cipher-aesgcm.c
+	../backend/sodium/cipher-aesgcm.c \
+	../backend/ref/cipher-aesgcm.c
 else
 libnoiseprotocol_a_SOURCES += \
 	../backend/ref/cipher-aesgcm.c
@@ -85,7 +86,9 @@ libnoiseprotocol_a_SOURCES += \
 	../backend/sodium/hash-blake2b.c \
 	../backend/sodium/hash-sha256.c \
 	../backend/sodium/hash-sha512.c \
-	../backend/sodium/sign-ed25519.c
+	../backend/sodium/sign-ed25519.c \
+	../crypto/aes/rijndael-alg-fst.c \
+	../crypto/ghash/ghash.c
 else !USE_LIBSODIUM
 libnoiseprotocol_a_SOURCES += \
 	rand_os.c \

--- a/src/protocol/internal.c
+++ b/src/protocol/internal.c
@@ -23,7 +23,7 @@
 
 #include "internal.h"
 
-#if USE_SODIUM
+#if USE_LIBSODIUM
 NoiseCipherState *noise_aesgcm_new_sodium(void);
 #endif
 #if USE_OPENSSL
@@ -40,7 +40,7 @@ NoiseCipherState *noise_aesgcm_new_ref(void);
 NoiseCipherState *noise_aesgcm_new(void)
 {
     NoiseCipherState *state = 0;
-#if USE_SODIUM
+#if USE_LIBSODIUM
     if (crypto_aead_aes256gcm_is_available())
         state = noise_aesgcm_new_sodium();
 #endif


### PR DESCRIPTION
Syncs the fork with the 4 commits upstream `rweather/noise-c` has landed on `master` since the fork point (`9379e58`).

Only three files were touched upstream, and two of them are `Makefile.am` files belonging to the autotools build, which is vestigial in this fork (it still references `protobufs.h`, `SUBDIRS = keys`, and `sign-ed25519.c`, all of which were deleted here). I took those hunks verbatim rather than reverting them so future syncs do not re-conflict on the same lines. The real build is `CMakeLists.txt`, which already compiles both the `ref` and `sodium` `cipher-aesgcm.c` along with `rijndael-alg-fst.c`, so it already had the effect of upstream's build fix.

The third file, `src/protocol/internal.c`, conflicted. Upstream commit `3541938` fixes `USE_SODIUM` never being defined, which silently disabled the libsodium AES-GCM path. This fork had already fixed the same bug independently, renaming the macro to `NOISE_USE_LIBSODIUM` and adding a `NOISE_USE_AES` guard around the block, so the conflict is resolved to the fork's version and the file is unchanged by this merge.

Net result: no source-file changes, only the two dead autotools makefiles. Verified with a clean CMake configure and build of the non-ESP-IDF target; `libnoise_c.a` links with no new warnings.