### PR TITLE
Document generic CMake usage and point contact at this fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Noise-C Library
 ===============
 
-**Note**: This is a port of the [noise-c](https://github.com/rweather/noise-c) library to support 1. the [PlatformIO](https://platformio.org/) and [ESP-IDF](https://github.com/espressif/esp-idf) build systems and 2. ESP8266/ESP32 targets.
+**Note**: This is a port of the [noise-c](https://github.com/rweather/noise-c) library to build on microcontroller targets. It ships build support for [PlatformIO](https://platformio.org/), [ESP-IDF](https://github.com/espressif/esp-idf), and plain [CMake](https://cmake.org/), so it can be consumed by any microcontroller (or host) project that builds with CMake, not just ESP8266/ESP32.
 
 Noise-C is a plain C implementation of the
 [Noise Protocol](http://noiseprotocol.org), intended as a
@@ -13,6 +13,36 @@ distributed under the terms of the MIT license.
 The [documentation](http://rweather.github.io/noise-c/index.html)
 contains more information on the library, examples, and how to build it.
 
-For more information on this library, to report bugs, to contribute,
-or to suggest improvements, please contact the author Rhys Weatherley via
-[email](mailto:rhys.weatherley@gmail.com).
+Using it in a CMake project
+---------------------------
+
+The top-level `CMakeLists.txt` detects which build it is running under:
+
+* Under ESP-IDF (`ESP_PLATFORM` set) it registers itself as an IDF component,
+  requiring the `esphome__libsodium` component.
+* Anywhere else it defines a static library target `noise_c`, also available as
+  `esphome::noise_c`, with `include/` and `src/` on its public include path.
+
+So any CMake-based project - a vendor SDK, a bare-metal cross-compile toolchain,
+Zephyr, or a host build for tests - can pull it in with `add_subdirectory()` (or
+`FetchContent`) and link the target:
+
+```cmake
+add_subdirectory(third_party/noise-c)
+target_link_libraries(my_app PRIVATE esphome::noise_c)
+```
+
+The crypto backend is a compile-time choice made through the `NOISE_USE_*`
+macros in `include/noise/defines.h`. The default backend is libsodium; if your
+project already defines a `sodium` target before `add_subdirectory()`, the
+generic build links against it automatically. Otherwise select the reference
+backend (or provide libsodium yourself) before building.
+
+Minimum CMake version for the generic target is 3.13.
+
+This fork is maintained by the [ESPHome](https://esphome.io) project. To report
+bugs, contribute, or suggest improvements to it, please open an issue or pull
+request on [esphome-libs/noise-c](https://github.com/esphome-libs/noise-c/issues).
+
+The original library was written by Rhys Weatherley; questions about upstream
+Noise-C itself belong on [rweather/noise-c](https://github.com/rweather/noise-c).


### PR DESCRIPTION
Since #14 added a generic CMake target, this library is no longer limited to ESP8266/ESP32 via PlatformIO or ESP-IDF: any CMake-based project can consume it. The README still described it as an ESP-only port, so this updates the intro and adds a short section covering what the top-level `CMakeLists.txt` exposes (`noise_c` / `esphome::noise_c`, the include paths, the libsodium backend caveat, and the CMake 3.13 minimum) along with an `add_subdirectory()` example.

Also repoints the closing paragraph at this fork's issue tracker rather than the original author's personal email, since this fork is the one being maintained. Upstream attribution to Rhys Weatherley is kept, with questions about Noise-C itself directed to rweather/noise-c.

Documentation changes only, no code or build changes.