### PR TITLE
Add minimum permissions to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,11 +4,15 @@ on:
   release:
     types: [published]
 
+permissions: {}
+
 jobs:
   publish-platformio:
     name: Publish to PlatformIO
     runs-on: ubuntu-latest
     environment: platformio
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Set up Python
@@ -26,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: espressif
     permissions:
+      contents: read
       id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
The publish workflow had no top-level `permissions` block, so `GITHUB_TOKEN` fell back to the repository/organisation default, which is often read-write on all scopes. This sets the workflow default to `permissions: {}` and grants each job only what it actually needs.

- `publish-platformio`: `contents: read` for `actions/checkout`.
- `publish-espressif`: `contents: read` added alongside the existing `id-token: write`.