### PR TITLE
Add Release Drafter workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,33 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+categories:
+  - title: "Breaking Changes"
+    label: "breaking-change"
+  - title: "Dependencies"
+    collapse-after: 1
+    labels:
+      - "dependencies"
+
+version-resolver:
+  major:
+    labels:
+      - "major"
+      - "breaking-change"
+  minor:
+    labels:
+      - "minor"
+      - "new-feature"
+  patch:
+    labels:
+      - "bugfix"
+      - "dependencies"
+      - "documentation"
+      - "enhancement"
+  default: patch
+
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,7 +3,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - esp-port
+      - main
 
 permissions: {}
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,45 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - esp-port
+
+permissions: {}
+
+jobs:
+  release-drafter:
+    name: Release Drafter
+    environment: release-drafter
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
+        id: drafter
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+
+      - name: Update version files
+        run: |
+          sed -i "s/^version: .*/version: \"${{ steps.drafter.outputs.resolved_version }}\"/g" idf_component.yml
+          sed -i "s/^    \"version\": .*/    \"version\": \"${{ steps.drafter.outputs.resolved_version }}\",/g" library.json
+
+      - name: Commit changes
+        run: |
+          if ! git diff --quiet; then
+            git config --global user.name "esphome-libs[bot]"
+            git config --global user.email "272321744+esphome-libs[bot]@users.noreply.github.com"
+            git add idf_component.yml library.json
+            git commit -m "Bump version to ${{ steps.drafter.outputs.resolved_version }}"
+            git push
+          fi


### PR DESCRIPTION
Adds Release Drafter so releases are drafted automatically from merged PRs, matching the setup used across the other esphome-libs repos.

`.github/release-drafter.yml` uses the same config as the sibling libs: `v$RESOLVED_VERSION` name/tag templates (matching the existing `v0.1.13` tags), Breaking Changes and Dependencies categories, and a label-driven version resolver that defaults to patch.

`.github/workflows/release-drafter.yml` runs on push to `esp-port`, drafts the release, then bumps the version in `idf_component.yml` and `library.json` and commits as `esphome-libs[bot]`. The `library.json` substitution is anchored to the four-space top-level `"version":` line so it does not also rewrite the nested libsodium dependency version.

Actions are pinned to the peeled commit SHAs of their current latest tags: `create-github-app-token` v3.2.0, `checkout` v7.0.1, `release-drafter` v7.7.0.

This needs the `release-drafter` environment on the repo, along with the `ESPHOME_GITHUB_APP_CLIENT_ID` variable and the `ESPHOME_GITHUB_APP_PRIVATE_KEY` secret.