### PR TITLE
Bump libsodium dependency to 1.10021.2

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -2,4 +2,4 @@ description: noise-c
 version: "0.1.14"
 repository: https://github.com/esphome/noise-c.git
 dependencies:
-  esphome/libsodium: "1.10021.1"
+  esphome/libsodium: "1.10021.2"


### PR DESCRIPTION
Updates the `esphome/libsodium` dependency in `idf_component.yml` from 1.10021.1 to 1.10021.2 so builds pull the latest libsodium component release.