### PR TITLE
Move ChaChaPoly per-operation scratch to the stack

### DIFF
--- a/src/backend/sodium/cipher-chachapoly.c
+++ b/src/backend/sodium/cipher-chachapoly.c
@@ -32,11 +32,25 @@ typedef struct
 {
     struct NoiseCipherState_s parent;
     uint8_t chacha_k[crypto_stream_chacha20_KEYBYTES];
+} NoiseChaChaPolyState;
+
+/*
+ * Per-operation working state. Only the key and nonce counter persist
+ * between calls, so this lives on the stack during encrypt/decrypt and
+ * is wiped before returning. Keeping it out of NoiseChaChaPolyState
+ * shrinks each long-lived cipher state by over 300 bytes, which matters
+ * on embedded targets that hold two cipher states per connection.
+ * The trade is ~336 bytes of stack for the duration of each call,
+ * below what the curve25519 handshake steps already require.
+ * The wipe uses sodium_memzero, not noise_clean: the latter is a
+ * volatile byte loop that costs ~47% on 64-byte frames.
+ */
+typedef struct
+{
     uint8_t chacha_n[crypto_stream_chacha20_IETF_NONCEBYTES];
     crypto_onetimeauth_poly1305_state poly1305;
     uint8_t block[64];
-
-} NoiseChaChaPolyState;
+} NoiseChaChaPolyScratch;
 
 static void noise_chachapoly_init_key
     (NoiseCipherState *state, const uint8_t *key)
@@ -58,54 +72,58 @@ static void noise_chachapoly_init_key
     } while (0)
 
 /**
- * \brief Sets up a ChaChaPoly context to encrypt/decrypt a block.
+ * \brief Sets up a ChaChaPoly scratch area to encrypt/decrypt a block.
  *
  * \param st The encryption state for ChaChaPoly.
+ * \param sc The stack scratch area for this operation.
  * \param n The nonce for this block.
  */
-static void noise_chachapoly_setup(NoiseChaChaPolyState *st, uint64_t n)
+static void noise_chachapoly_setup
+    (const NoiseChaChaPolyState *st, NoiseChaChaPolyScratch *sc, uint64_t n)
 {
     /* The 96-bit nonce is formed by encoding 32 bits of zeros followed by little-endian encoding of n */
-    memset(st->chacha_n, 0, 4);
-    PUT_UINT64_LE(st->chacha_n + 4, n);
+    memset(sc->chacha_n, 0, 4);
+    PUT_UINT64_LE(sc->chacha_n + 4, n);
 
-    /* Encrypt an initial block to create the Poly1305 key */
-    memset(st->block, 0, 64);
-    crypto_stream_chacha20_ietf_xor(st->block, st->block, 64, st->chacha_n, st->chacha_k);
-    crypto_onetimeauth_poly1305_init(&(st->poly1305), st->block);
-    noise_clean(st->block, sizeof(st->block));
+    /* Encrypt an initial block to create the Poly1305 key. The key stays
+       in sc->block until the caller wipes the scratch. (memset + _xor of a
+       full block benchmarks faster here than generating 32 keystream bytes
+       with crypto_stream_chacha20_ietf.) */
+    memset(sc->block, 0, 64);
+    crypto_stream_chacha20_ietf_xor(sc->block, sc->block, 64, sc->chacha_n, st->chacha_k);
+    crypto_onetimeauth_poly1305_init(&(sc->poly1305), sc->block);
 }
 
 /**
  * \brief Pads the Poly1305 input to a multiple of 16 bytes.
  *
- * \param st The encryption state for ChaChaPoly.
+ * \param sc The stack scratch area for this operation.
  * \param len The length of the input that needs to be padded.
  */
-static void noise_chachapoly_pad_auth(NoiseChaChaPolyState *st, size_t len)
+static void noise_chachapoly_pad_auth(NoiseChaChaPolyScratch *sc, size_t len)
 {
     len %= 16;
     if (len) {
         static uint8_t const padding[16] = {
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
         };
-        crypto_onetimeauth_poly1305_update(&(st->poly1305), padding, 16 - len);
+        crypto_onetimeauth_poly1305_update(&(sc->poly1305), padding, 16 - len);
     }
 }
 
 /**
  * \brief Finalize the Poly1305 hash by adding the lengths.
  *
- * \param st The encryption state for ChaChaPoly.
+ * \param sc The stack scratch area for this operation.
  * \param ad_len The length of the associated data.
  * \param data_len The length of the ciphertext.
  */
 static void noise_chachapoly_auth_lengths
-    (NoiseChaChaPolyState *st, uint64_t ad_len, uint64_t data_len)
+    (NoiseChaChaPolyScratch *sc, uint64_t ad_len, uint64_t data_len)
 {
-    PUT_UINT64_LE(st->block, ad_len);
-    PUT_UINT64_LE(st->block + 8, data_len);
-    crypto_onetimeauth_poly1305_update(&(st->poly1305), st->block, 16);
+    PUT_UINT64_LE(sc->block, ad_len);
+    PUT_UINT64_LE(sc->block + 8, data_len);
+    crypto_onetimeauth_poly1305_update(&(sc->poly1305), sc->block, 16);
 }
 
 static int noise_chachapoly_encrypt
@@ -113,16 +131,18 @@ static int noise_chachapoly_encrypt
      uint8_t *data, size_t len)
 {
     NoiseChaChaPolyState *st = (NoiseChaChaPolyState *)state;
-    noise_chachapoly_setup(st, state->n);
+    NoiseChaChaPolyScratch sc;
+    noise_chachapoly_setup(st, &sc, state->n);
     if (ad_len) {
-        crypto_onetimeauth_poly1305_update(&(st->poly1305), ad, ad_len);
-        noise_chachapoly_pad_auth(st, ad_len);
+        crypto_onetimeauth_poly1305_update(&(sc.poly1305), ad, ad_len);
+        noise_chachapoly_pad_auth(&sc, ad_len);
     }
-    crypto_stream_chacha20_ietf_xor_ic(data, data, len, st->chacha_n, 1U, st->chacha_k);
-    crypto_onetimeauth_poly1305_update(&(st->poly1305), data, len);
-    noise_chachapoly_pad_auth(st, len);
-    noise_chachapoly_auth_lengths(st, ad_len, len);
-    crypto_onetimeauth_poly1305_final(&(st->poly1305), data + len);
+    crypto_stream_chacha20_ietf_xor_ic(data, data, len, sc.chacha_n, 1U, st->chacha_k);
+    crypto_onetimeauth_poly1305_update(&(sc.poly1305), data, len);
+    noise_chachapoly_pad_auth(&sc, len);
+    noise_chachapoly_auth_lengths(&sc, ad_len, len);
+    crypto_onetimeauth_poly1305_final(&(sc.poly1305), data + len);
+    sodium_memzero(&sc, sizeof(sc));
     return NOISE_ERROR_NONE;
 }
 
@@ -131,19 +151,22 @@ static int noise_chachapoly_decrypt
      uint8_t *data, size_t len)
 {
     NoiseChaChaPolyState *st = (NoiseChaChaPolyState *)state;
-    noise_chachapoly_setup(st, state->n);
+    NoiseChaChaPolyScratch sc;
+    int ok;
+    noise_chachapoly_setup(st, &sc, state->n);
     if (ad_len) {
-        crypto_onetimeauth_poly1305_update(&(st->poly1305), ad, ad_len);
-        noise_chachapoly_pad_auth(st, ad_len);
+        crypto_onetimeauth_poly1305_update(&(sc.poly1305), ad, ad_len);
+        noise_chachapoly_pad_auth(&sc, ad_len);
     }
-    crypto_onetimeauth_poly1305_update(&(st->poly1305), data, len);
-    noise_chachapoly_pad_auth(st, len);
-    noise_chachapoly_auth_lengths(st, ad_len, len);
-    crypto_onetimeauth_poly1305_final(&(st->poly1305), st->block);
-    if (!noise_is_equal(st->block, data + len, 16))
-        return NOISE_ERROR_MAC_FAILURE;
-    crypto_stream_chacha20_ietf_xor_ic(data, data, len, st->chacha_n, 1U, st->chacha_k);
-    return NOISE_ERROR_NONE;
+    crypto_onetimeauth_poly1305_update(&(sc.poly1305), data, len);
+    noise_chachapoly_pad_auth(&sc, len);
+    noise_chachapoly_auth_lengths(&sc, ad_len, len);
+    crypto_onetimeauth_poly1305_final(&(sc.poly1305), sc.block);
+    ok = noise_is_equal(sc.block, data + len, 16);
+    if (ok)
+        crypto_stream_chacha20_ietf_xor_ic(data, data, len, sc.chacha_n, 1U, st->chacha_k);
+    sodium_memzero(&sc, sizeof(sc));
+    return ok ? NOISE_ERROR_NONE : NOISE_ERROR_MAC_FAILURE;
 }
 
 NoiseCipherState *noise_chachapoly_new(void)


### PR DESCRIPTION
The sodium ChaChaPoly cipher state kept 332 bytes of per operation working memory resident for its whole lifetime; the poly1305 state, the nonce buffer, and a 64 byte block are fully reinitialized at the start of every encrypt and decrypt, only the 32 byte key and the nonce counter actually persist between calls. That working memory now lives on the stack during each call and is wiped with `sodium_memzero` before returning, including on MAC failure.

Each cipher state shrinks from 416 to 80 bytes on 32 bit targets. ESPHome holds two cipher states per encrypted API connection after the handshake split, so every open connection frees 672 bytes of heap. Stack cost is about 340 bytes during a call, well under what the curve25519 handshake steps already need.

Correctness, verified on host against libsodium 1.0.20: ciphertext and MAC are byte identical to libsodium's `crypto_aead_chacha20poly1305_ietf_encrypt` for successive nonces, 100 encrypt/decrypt round trips pass, tampered ciphertext fails with MAC_FAILURE, and a full Noise_NNpsk0_25519_ChaChaPoly_SHA256 handshake loopback with data frames in both directions passes.

Performance, encrypt on an M series host, ns per operation, three runs each within noise:

| payload | before | after |
|---|---|---|
| 64 B | 187.8 | 182.7 |
| 512 B | 777.6 | 769.4 |
| 1390 B | 1979.1 | 1959.4 |

The wipe uses `sodium_memzero` rather than `noise_clean` because the latter is a volatile byte loop that added 47 percent on 64 byte frames when benchmarked; with `sodium_memzero` the change is performance neutral, the slight edge above comes from dropping the old 64 byte `noise_clean` inside setup.

Measured on real ESP8266 hardware (esp01_1m at 80 MHz, OTA A/B of the same config, encrypt ns are us per op, two runs each within 0.1 us):

| payload | 0.1.11 | this branch |
|---|---|---|
| cipher state alloc | 416 B | 80 B |
| 64 B | 185.4 us | 183.4 us |
| 512 B | 965.7 us | 963.8 us |
| 1390 B | 2521.9 us | 2519.2 us |
