### PR TITLE
Bump version to 0.1.16

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,5 +1,5 @@
 description: noise-c
-version: "0.1.15"
+version: "0.1.16"
 repository: https://github.com/esphome/noise-c.git
 dependencies:
   esphome/libsodium: "1.10021.2"

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "noise-c",
-    "version": "0.1.15",
+    "version": "0.1.16",
     "description": "noise-c",
     "keywords": "noise-c",
     "repository": {


### PR DESCRIPTION
Version bump for the v0.1.16 release; the tag was published before the bump landed, so the PlatformIO publish job read 0.1.15 from library.json and failed. After merging, the v0.1.16 tag needs to move to this commit and the publish job re-run.