### PR TITLE
Bump version to 0.1.17

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,5 +1,5 @@
 description: noise-c
-version: "0.1.16"
+version: "0.1.17"
 repository: https://github.com/esphome/noise-c.git
 dependencies:
   esphome/libsodium: "1.10021.2"

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "noise-c",
-    "version": "0.1.16",
+    "version": "0.1.17",
     "description": "noise-c",
     "keywords": "noise-c",
     "repository": {


### PR DESCRIPTION
The v0.1.16 release was tagged before its version bump landed, so the PlatformIO publish read 0.1.15 and failed; GitHub platform issues then blocked rerunning the job. Cutting 0.1.17 with the version files in place so a fresh release publishes cleanly to both registries.

Given https://www.githubstatus.com/ is having an incident right now another bump is cleaner