### PR TITLE
Align library.json libsodium pin with idf_component.yml

### DIFF
--- a/library.json
+++ b/library.json
@@ -20,7 +20,7 @@
         {
             "owner": "esphome",
             "name": "libsodium",
-            "version": "1.10021.1"
+            "version": "1.10021.2"
         }
     ]
 }


### PR DESCRIPTION
PR #19 bumped libsodium to 1.10021.2 in idf_component.yml only, so the two registries ship different transitive pins; PlatformIO consumers still resolve 1.10021.1. This aligns library.json to 1.10021.2, which is published on the PlatformIO registry. Verified the constraint still intersects esp_wireguard's ^1.10018.1 used by esphome.