### PR TITLE
Bump version to 0.1.18

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,5 +1,5 @@
 description: noise-c
-version: "0.1.17"
+version: "0.1.18"
 repository: https://github.com/esphome/noise-c.git
 dependencies:
   esphome/libsodium: "1.10021.2"

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "noise-c",
-    "version": "0.1.17",
+    "version": "0.1.18",
     "description": "noise-c",
     "keywords": "noise-c",
     "repository": {


### PR DESCRIPTION
Version bump for the 0.1.18 release, which aligns the library.json libsodium pin (1.10021.2) with idf_component.yml (#23).