### PR TITLE
Bump libsodium to 1.10021.3

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -2,4 +2,4 @@ description: noise-c
 version: "0.1.18"
 repository: https://github.com/esphome/noise-c.git
 dependencies:
-  esphome/libsodium: "1.10021.2"
+  esphome/libsodium: "1.10021.3"

--- a/library.json
+++ b/library.json
@@ -20,7 +20,7 @@
         {
             "owner": "esphome",
             "name": "libsodium",
-            "version": "1.10021.2"
+            "version": "1.10021.3"
         }
     ]
 }


### PR DESCRIPTION
Picks up the ESP8266 scalar multiplication yields from esphome-libs/libsodium#31, which eliminate multi second noise handshake stalls caused by WiFi RX queue overflow during the unyielding curve25519 window; measured on hardware at 0 stalls in 24 attempts versus 12 of 12 before. Both manifests now pin the same libsodium version.