### PR TITLE
Use single pass ChaCha20 setup and session key schedule in sodium backend

### DIFF
--- a/src/backend/sodium/cipher-chachapoly.c
+++ b/src/backend/sodium/cipher-chachapoly.c
@@ -34,12 +34,19 @@
 # endif
 #endif
 
-#ifdef SODIUM_ESPHOME_NOISE_FAST_PATH
+#if defined(SODIUM_ESPHOME_NOISE_FAST_PATH) && \
+    SODIUM_ESPHOME_NOISE_FAST_PATH >= 1 && \
+    !defined(NOISE_DISABLE_SODIUM_FAST_PATH)
 
 /*
  * Fast path for the esphome libsodium port: the ChaCha20 key schedule is
  * loaded once per session, the Poly1305 key block and the payload share one
  * cipher pass, and the whole MAC transcript is one call.
+ *
+ * SODIUM_ESPHOME_NOISE_FAST_PATH is a version number; the port bumps it if
+ * the semantics of the session entry points ever change, which downgrades
+ * this file to the fallback instead of miscomputing. Define
+ * NOISE_DISABLE_SODIUM_FAST_PATH to force the fallback.
  */
 
 typedef struct

--- a/src/backend/sodium/cipher-chachapoly.c
+++ b/src/backend/sodium/cipher-chachapoly.c
@@ -35,7 +35,7 @@
 #endif
 
 #if defined(SODIUM_ESPHOME_NOISE_FAST_PATH) && \
-    SODIUM_ESPHOME_NOISE_FAST_PATH >= 1 && \
+    SODIUM_ESPHOME_NOISE_FAST_PATH == 1 && \
     !defined(NOISE_DISABLE_SODIUM_FAST_PATH)
 
 /*
@@ -43,7 +43,9 @@
  * loaded once per session, the Poly1305 key block and the payload share one
  * cipher pass, and the whole MAC transcript is one call. The aead_mac
  * entry point accepts a NULL ad when ad_len is 0, so the ad branch needs
- * no guard here.
+ * no guard here, and block0_xor accepts NULL in and out pointers when len
+ * is 0, deriving only the key block and leaving the counter at 1 for the
+ * decrypt payload pass.
  *
  * To exercise this path off target, add_subdirectory this repo and the
  * esphome libsodium port (patches applied) into one CMake build; the port
@@ -51,9 +53,10 @@
  * test then runs the RFC 7539 vector through the fast path.
  *
  * SODIUM_ESPHOME_NOISE_FAST_PATH is a version number; the port bumps it if
- * the semantics of the session entry points ever change, which downgrades
- * this file to the fallback instead of miscomputing. Define
- * NOISE_DISABLE_SODIUM_FAST_PATH to force the fallback.
+ * the semantics of the session entry points ever change, and the exact
+ * match above downgrades this file to the fallback until it is updated
+ * for the new semantics on purpose. Define NOISE_DISABLE_SODIUM_FAST_PATH
+ * to force the fallback.
  */
 
 typedef struct

--- a/src/backend/sodium/cipher-chachapoly.c
+++ b/src/backend/sodium/cipher-chachapoly.c
@@ -28,6 +28,74 @@
 #include <sodium.h>
 #include <string.h>
 
+#if defined(__has_include)
+# if __has_include(<sodium/sodium_esphome.h>)
+#  include <sodium/sodium_esphome.h>
+# endif
+#endif
+
+#ifdef SODIUM_ESPHOME_NOISE_FAST_PATH
+
+/*
+ * Fast path for the esphome libsodium port: the ChaCha20 key schedule is
+ * loaded once per session, the Poly1305 key block and the payload share one
+ * cipher pass, and the whole MAC transcript is one call.
+ */
+
+typedef struct
+{
+    struct NoiseCipherState_s parent;
+    /* Session persistent ChaCha20 key schedule; loaded once per key, only
+       the nonce and counter words are rewritten per message. */
+    crypto_stream_chacha20_ietf_session_state chacha_st;
+} NoiseChaChaPolyState;
+
+static void noise_chachapoly_init_key
+    (NoiseCipherState *state, const uint8_t *key)
+{
+    NoiseChaChaPolyState *st = (NoiseChaChaPolyState *)state;
+    crypto_stream_chacha20_ietf_session_init(&(st->chacha_st), key);
+}
+
+static int noise_chachapoly_encrypt
+    (NoiseCipherState *state, const uint8_t *ad, size_t ad_len,
+     uint8_t *data, size_t len)
+{
+    NoiseChaChaPolyState *st = (NoiseChaChaPolyState *)state;
+    uint8_t block[64] __attribute__((aligned(4)));
+
+    /* Poly1305 key generation and payload encryption share one cipher
+       setup. block is deliberately not wiped: it is derived from the
+       session key that stays resident in the cipher state, and there is
+       no memory segmentation on these targets. */
+    crypto_stream_chacha20_ietf_session_block0_xor
+        (&(st->chacha_st), block, data, data, len, state->n);
+    crypto_onetimeauth_poly1305_aead_mac
+        (data + len, ad, ad_len, data, len, block);
+    return NOISE_ERROR_NONE;
+}
+
+static int noise_chachapoly_decrypt
+    (NoiseCipherState *state, const uint8_t *ad, size_t ad_len,
+     uint8_t *data, size_t len)
+{
+    NoiseChaChaPolyState *st = (NoiseChaChaPolyState *)state;
+    uint8_t block[64] __attribute__((aligned(4)));
+    uint8_t mac[16];
+
+    crypto_stream_chacha20_ietf_session_block0_xor
+        (&(st->chacha_st), block, NULL, NULL, 0, state->n);
+    crypto_onetimeauth_poly1305_aead_mac(mac, ad, ad_len, data, len, block);
+    if (!noise_is_equal(mac, data + len, 16))
+        return NOISE_ERROR_MAC_FAILURE;
+    /* The session state's block counter is already at 1 after the key
+       generation call above */
+    crypto_stream_chacha20_ietf_session_xor(&(st->chacha_st), data, data, len);
+    return NOISE_ERROR_NONE;
+}
+
+#else /* stock libsodium fallback */
+
 typedef struct
 {
     struct NoiseCipherState_s parent;
@@ -182,6 +250,8 @@ static int noise_chachapoly_decrypt
     crypto_stream_chacha20_ietf_xor_ic(data, data, len, sc.chacha_n, 1U, st->chacha_k);
     return NOISE_ERROR_NONE;
 }
+
+#endif /* stock libsodium fallback */
 
 NoiseCipherState *noise_chachapoly_new(void)
 {

--- a/src/backend/sodium/cipher-chachapoly.c
+++ b/src/backend/sodium/cipher-chachapoly.c
@@ -41,7 +41,14 @@
 /*
  * Fast path for the esphome libsodium port: the ChaCha20 key schedule is
  * loaded once per session, the Poly1305 key block and the payload share one
- * cipher pass, and the whole MAC transcript is one call.
+ * cipher pass, and the whole MAC transcript is one call. The aead_mac
+ * entry point accepts a NULL ad when ad_len is 0, so the ad branch needs
+ * no guard here.
+ *
+ * To exercise this path off target, add_subdirectory this repo and the
+ * esphome libsodium port (patches applied) into one CMake build; the port
+ * exports the `sodium` target this repo links, and the cipherstate unit
+ * test then runs the RFC 7539 vector through the fast path.
  *
  * SODIUM_ESPHOME_NOISE_FAST_PATH is a version number; the port bumps it if
  * the semantics of the session entry points ever change, which downgrades

--- a/src/backend/sodium/cipher-chachapoly.c
+++ b/src/backend/sodium/cipher-chachapoly.c
@@ -72,13 +72,12 @@ static int noise_chachapoly_encrypt
     uint8_t block[64] __attribute__((aligned(4)));
 
     /* Poly1305 key generation and payload encryption share one cipher
-       setup. block is deliberately not wiped: it is derived from the
-       session key that stays resident in the cipher state, and there is
-       no memory segmentation on these targets. */
+       setup; the key in block is cleared as soon as the MAC is done */
     crypto_stream_chacha20_ietf_session_block0_xor
         (&(st->chacha_st), block, data, data, len, state->n);
     crypto_onetimeauth_poly1305_aead_mac
         (data + len, ad, ad_len, data, len, block);
+    sodium_memzero(block, 32);
     return NOISE_ERROR_NONE;
 }
 
@@ -93,8 +92,13 @@ static int noise_chachapoly_decrypt
     crypto_stream_chacha20_ietf_session_block0_xor
         (&(st->chacha_st), block, NULL, NULL, 0, state->n);
     crypto_onetimeauth_poly1305_aead_mac(mac, ad, ad_len, data, len, block);
-    if (!noise_is_equal(mac, data + len, 16))
+    sodium_memzero(block, 32);
+    if (!noise_is_equal(mac, data + len, 16)) {
+        /* the computed tag is valid for a nonce that stays live, since n
+           is not incremented on MAC failure */
+        sodium_memzero(mac, 16);
         return NOISE_ERROR_MAC_FAILURE;
+    }
     /* The session state's block counter is already at 1 after the key
        generation call above */
     crypto_stream_chacha20_ietf_session_xor(&(st->chacha_st), data, data, len);

--- a/src/backend/sodium/cipher-chachapoly.c
+++ b/src/backend/sodium/cipher-chachapoly.c
@@ -35,6 +35,13 @@
 #endif
 
 #if defined(SODIUM_ESPHOME_NOISE_FAST_PATH) && \
+    SODIUM_ESPHOME_NOISE_FAST_PATH != 1 && \
+    !defined(NOISE_DISABLE_SODIUM_FAST_PATH)
+#pragma message( \
+    "noise-c: sodium fast path disabled, unrecognised SODIUM_ESPHOME_NOISE_FAST_PATH version")
+#endif
+
+#if defined(SODIUM_ESPHOME_NOISE_FAST_PATH) && \
     SODIUM_ESPHOME_NOISE_FAST_PATH == 1 && \
     !defined(NOISE_DISABLE_SODIUM_FAST_PATH)
 


### PR DESCRIPTION
## Summary

Adds a fast path for the esphome libsodium port (esphome-libs/libsodium#32) in the sodium ChaChaPoly backend, feature detected via `sodium/sodium_esphome.h`; the current implementation stays as the fallback for stock libsodium.

The main consumer of this path today is log message streaming over the encrypted API, small messages where the per message fixed cost dominates, which is what these changes target. OTA over noise is planned eventually; that shifts the focus to bulk throughput, where larger noise frames amortize the fixed cost and a hand tuned chacha loop remains as a follow up.

The changes:

1. The cipher state holds a session persistent ChaCha20 key schedule (`crypto_stream_chacha20_ietf_session_state`) loaded once in `init_key`, instead of running a full key setup twice per message; per message only the nonce and counter words are rewritten.
2. Encrypt generates the Poly1305 key block and encrypts the payload in a single cipher pass; decrypt derives the key the same way, then continues the keystream from counter 1 after the MAC check.
3. The whole MAC transcript (ad, padding, ciphertext, padding, lengths) is one `crypto_onetimeauth_poly1305_aead_mac` call instead of five dispatched init/update/final calls.

## Benchmarks

ESP32 (Xtensa LX6, 240 MHz, ESP-IDF), `noise_cipherstate_encrypt` with the same pattern as `APINoiseFrameHelper::write_protobuf_messages`, together with the libsodium patches:

| Size | Before | After |
|------|--------|-------|
| 50 B | 37.4 µs/op | 27.4 µs/op (27% faster) |
| 100 B | 48.8 µs/op | 38.9 µs/op (20% faster) |
| 1000 B | 234.3 µs/op | 222.2 µs/op (5% faster) |

ESP8266 (Xtensa LX106, 80 MHz, Arduino), same benchmark:

| Size | Before | After |
|------|--------|-------|
| 50 B | 190.4 µs/op | 160.2 µs/op (16% faster) |
| 100 B | 267.6 µs/op | 240.8 µs/op (10% faster) |
| 1000 B | 1672.6 µs/op | 1650.4 µs/op (1% faster) |

## Memory

Measured on the same builds: ESP32 flash grows 124 bytes and static RAM is unchanged; ESP8266 flash shrinks 956 bytes and static RAM shrinks 52 bytes (the fast path uses fewer libsodium entry points, so more code is dead stripped). Each cipher state grows 32 bytes (key schedule instead of raw key), 64 bytes per connection. Peak stack per crypto call drops from about 880 to about 528 bytes because the per operation scratch, the stacked cipher context and two wrapper frames are gone.

## Verification

The RFC 7539 A.5 ChaChaPoly vector (`tests/unit/test-cipherstate.c`, nonzero nonce, nonzero ad, byte exact ciphertext and tag, decrypt round trip and MAC failure paths) passes on a host build linked against the patched libsodium port with the fast path confirmed in the binary; to reproduce, add_subdirectory both repos with the port's patches applied (the port exports the `sodium` CMake target that this repo's CMakeLists links) and build the cipherstate test against `noise_c`. An encrypted API session (handshake plus bidirectional traffic) also works on ESP32 and ESP8266; the MAC transcript is unchanged, so it interoperates with existing peers; building against stock libsodium keeps the previous implementation via the capability guard, and `NOISE_DISABLE_SODIUM_FAST_PATH` forces it.

Depends on a libsodium release containing esphome-libs/libsodium#32; the dependency pin bump can follow the usual flow once that ships.
