### PR TITLE
Clear secrets at point of death instead of bulk wiping the scratch

### DIFF
--- a/src/backend/sodium/cipher-chachapoly.c
+++ b/src/backend/sodium/cipher-chachapoly.c
@@ -37,19 +37,21 @@ typedef struct
 /*
  * Per-operation working state. Only the key and nonce counter persist
  * between calls, so this lives on the stack during encrypt/decrypt.
- * The scratch is deliberately not wiped on return: the poly1305 state is
- * already wiped inside crypto_onetimeauth_poly1305_final, the nonce is
- * public, and the per-message Poly1305 key in block is derived from the
- * session key that stays resident in the cipher state anyway; on a single
- * address space firmware target a stack wipe adds cost without closing
- * any exposure the resident session key does not already have.
- * Keeping it out of NoiseChaChaPolyState
- * shrinks each long-lived cipher state by over 300 bytes, which matters
- * on embedded targets that hold two cipher states per connection.
- * The trade is ~336 bytes of stack for the duration of each call,
- * below what the curve25519 handshake steps already require.
- * The wipe uses sodium_memzero, not noise_clean: the latter is a
- * volatile byte loop that costs ~47% on 64-byte frames.
+ * Keeping it out of NoiseChaChaPolyState shrinks each long-lived cipher
+ * state by over 300 bytes, which matters on embedded targets that hold
+ * two cipher states per connection. The trade is ~336 bytes of stack for
+ * the duration of each call, below what the curve25519 handshake steps
+ * already require.
+ *
+ * The scratch is deliberately not wiped on return. The nonce is public
+ * and libsodium wipes the poly1305 state inside
+ * crypto_onetimeauth_poly1305_final, leaving only the per-message
+ * Poly1305 key in block. That key is single use (each message has a
+ * fresh nonce) and is derived from the session key held in the cipher
+ * state, and these firmware targets run one program in one address
+ * space, so stale stack is only reachable by an attacker who can
+ * already read live memory. A full wipe here measured 9 to 13 percent
+ * of a small message operation.
  */
 typedef struct
 {
@@ -91,8 +93,8 @@ static void noise_chachapoly_setup
     memset(sc->chacha_n, 0, 4);
     PUT_UINT64_LE(sc->chacha_n + 4, n);
 
-    /* Encrypt an initial block to create the Poly1305 key. The key stays
-       in sc->block until the caller wipes the scratch. (memset + _xor of a
+    /* Encrypt an initial block to create the Poly1305 key, which stays
+       in sc->block for the rest of the operation. (memset + _xor of a
        full block benchmarks faster here than generating 32 keystream bytes
        with crypto_stream_chacha20_ietf.) */
     memset(sc->block, 0, 64);

--- a/src/backend/sodium/cipher-chachapoly.c
+++ b/src/backend/sodium/cipher-chachapoly.c
@@ -43,15 +43,13 @@ typedef struct
  * the duration of each call, below what the curve25519 handshake steps
  * already require.
  *
- * The scratch is deliberately not wiped on return. The nonce is public
- * and libsodium wipes the poly1305 state inside
- * crypto_onetimeauth_poly1305_final, leaving only the per-message
- * Poly1305 key in block. That key is single use (each message has a
- * fresh nonce) and is derived from the session key held in the cipher
- * state, and these firmware targets run one program in one address
- * space, so stale stack is only reachable by an attacker who can
- * already read live memory. A full wipe here measured 9 to 13 percent
- * of a small message operation.
+ * The scratch is not bulk wiped on return; a full wipe measured 9 to 13
+ * percent of a small message operation. Instead the secrets are cleared
+ * at the point they die: the Poly1305 key right after state init in
+ * setup(), and on decrypt failure the computed tag (its nonce stays
+ * live because n is not incremented on error). What remains after
+ * return is public or unused keystream, and libsodium wipes the
+ * poly1305 state inside crypto_onetimeauth_poly1305_final.
  */
 typedef struct
 {
@@ -100,6 +98,11 @@ static void noise_chachapoly_setup
     memset(sc->block, 0, 64);
     crypto_stream_chacha20_ietf_xor(sc->block, sc->block, 64, sc->chacha_n, st->chacha_k);
     crypto_onetimeauth_poly1305_init(&(sc->poly1305), sc->block);
+    /* The Poly1305 key is dead once the state is initialized; clear it so
+       the frame releases without key material (the other 32 bytes are
+       unused keystream). This matches the ref backend and costs a tenth
+       of the full scratch wipe this file used to do. */
+    sodium_memzero(sc->block, 32);
 }
 
 /**
@@ -170,9 +173,14 @@ static int noise_chachapoly_decrypt
     noise_chachapoly_auth_lengths(&sc, ad_len, len);
     crypto_onetimeauth_poly1305_final(&(sc.poly1305), sc.block);
     ok = noise_is_equal(sc.block, data + len, 16);
-    if (ok)
-        crypto_stream_chacha20_ietf_xor_ic(data, data, len, sc.chacha_n, 1U, st->chacha_k);
-    return ok ? NOISE_ERROR_NONE : NOISE_ERROR_MAC_FAILURE;
+    if (!ok) {
+        /* the computed tag is valid for a nonce that stays live, since n
+           is not incremented on MAC failure */
+        sodium_memzero(sc.block, 16);
+        return NOISE_ERROR_MAC_FAILURE;
+    }
+    crypto_stream_chacha20_ietf_xor_ic(data, data, len, sc.chacha_n, 1U, st->chacha_k);
+    return NOISE_ERROR_NONE;
 }
 
 NoiseCipherState *noise_chachapoly_new(void)

--- a/src/backend/sodium/cipher-chachapoly.c
+++ b/src/backend/sodium/cipher-chachapoly.c
@@ -36,8 +36,14 @@ typedef struct
 
 /*
  * Per-operation working state. Only the key and nonce counter persist
- * between calls, so this lives on the stack during encrypt/decrypt and
- * is wiped before returning. Keeping it out of NoiseChaChaPolyState
+ * between calls, so this lives on the stack during encrypt/decrypt.
+ * The scratch is deliberately not wiped on return: the poly1305 state is
+ * already wiped inside crypto_onetimeauth_poly1305_final, the nonce is
+ * public, and the per-message Poly1305 key in block is derived from the
+ * session key that stays resident in the cipher state anyway; on a single
+ * address space firmware target a stack wipe adds cost without closing
+ * any exposure the resident session key does not already have.
+ * Keeping it out of NoiseChaChaPolyState
  * shrinks each long-lived cipher state by over 300 bytes, which matters
  * on embedded targets that hold two cipher states per connection.
  * The trade is ~336 bytes of stack for the duration of each call,
@@ -142,7 +148,6 @@ static int noise_chachapoly_encrypt
     noise_chachapoly_pad_auth(&sc, len);
     noise_chachapoly_auth_lengths(&sc, ad_len, len);
     crypto_onetimeauth_poly1305_final(&(sc.poly1305), data + len);
-    sodium_memzero(&sc, sizeof(sc));
     return NOISE_ERROR_NONE;
 }
 
@@ -165,7 +170,6 @@ static int noise_chachapoly_decrypt
     ok = noise_is_equal(sc.block, data + len, 16);
     if (ok)
         crypto_stream_chacha20_ietf_xor_ic(data, data, len, sc.chacha_n, 1U, st->chacha_k);
-    sodium_memzero(&sc, sizeof(sc));
     return ok ? NOISE_ERROR_NONE : NOISE_ERROR_MAC_FAILURE;
 }
 

--- a/src/backend/sodium/cipher-chachapoly.c
+++ b/src/backend/sodium/cipher-chachapoly.c
@@ -91,17 +91,17 @@ static void noise_chachapoly_setup
     memset(sc->chacha_n, 0, 4);
     PUT_UINT64_LE(sc->chacha_n + 4, n);
 
-    /* Encrypt an initial block to create the Poly1305 key, which stays
-       in sc->block for the rest of the operation. (memset + _xor of a
+    /* Encrypt an initial block to create the Poly1305 key. (memset + _xor of a
        full block benchmarks faster here than generating 32 keystream bytes
        with crypto_stream_chacha20_ietf.) */
     memset(sc->block, 0, 64);
     crypto_stream_chacha20_ietf_xor(sc->block, sc->block, 64, sc->chacha_n, st->chacha_k);
     crypto_onetimeauth_poly1305_init(&(sc->poly1305), sc->block);
     /* The Poly1305 key is dead once the state is initialized; clear it so
-       the frame releases without key material (the other 32 bytes are
-       unused keystream). This matches the ref backend and costs a tenth
-       of the full scratch wipe this file used to do. */
+       the frame releases without key material. This matches the ref
+       backend's clear-in-setup approach at a tenth of the cost of the
+       full scratch wipe this file used to do; the remaining 32 bytes are
+       discarded counter-0 keystream. */
     sodium_memzero(sc->block, 32);
 }
 


### PR DESCRIPTION
## Summary

Follow up to #20, which added `sodium_memzero(&sc, sizeof(sc))` at the end of encrypt and decrypt. The CodSpeed benchmarks in esphome flagged this as a 9 to 13 percent regression on the noise encrypt and decrypt paths; the flamegraph shows the new memzero as about 11 percent of a small message operation, since it wipes the whole 336 byte scratch on every message.

Instead of bulk wiping, clear the secrets at the point they die: the 32 byte Poly1305 key right after `crypto_onetimeauth_poly1305_init` in setup (matching the ref backend and the pre #20 hygiene at about a tenth of the removed wipe's cost), and on decrypt failure the computed tag, whose nonce stays live because `n` is not incremented on error. Everything else the scratch holds at return is public or unused keystream, and libsodium already wipes the poly1305 state inside `crypto_onetimeauth_poly1305_final`.
