### PR TITLE
Bump libsodium to 1.10021.4

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -2,4 +2,4 @@ description: noise-c
 version: "0.1.20"
 repository: https://github.com/esphome/noise-c.git
 dependencies:
-  esphome/libsodium: "1.10021.3"
+  esphome/libsodium: "1.10021.4"

--- a/library.json
+++ b/library.json
@@ -20,7 +20,7 @@
         {
             "owner": "esphome",
             "name": "libsodium",
-            "version": "1.10021.3"
+            "version": "1.10021.4"
         }
     ]
 }


### PR DESCRIPTION
## Summary

Picks up libsodium 1.10021.4, which adds the known answer and differential crypto test suite to that repo's CI (esphome-libs/libsodium#33); no source changes affect the primitives noise-c uses, so this is a routine dependency refresh. Both manifests move together.