### PR TITLE
Bump libsodium to 1.10021.5

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -2,4 +2,4 @@ description: noise-c
 version: "0.1.21"
 repository: https://github.com/esphome/noise-c.git
 dependencies:
-  esphome/libsodium: "1.10021.4"
+  esphome/libsodium: "1.10021.5"

--- a/library.json
+++ b/library.json
@@ -20,7 +20,7 @@
         {
             "owner": "esphome",
             "name": "libsodium",
-            "version": "1.10021.4"
+            "version": "1.10021.5"
         }
     ]
 }


### PR DESCRIPTION
Picks up esphome-libs/libsodium#34: the SHA-256 round constants move to flash on ESP8266, 256 bytes of DRAM back. Same two files as #28.