### PR TITLE
Add noise_handshakestate_set_local_ephemeral()

### DIFF
--- a/include/noise/protocol/handshakestate.h
+++ b/include/noise/protocol/handshakestate.h
@@ -49,6 +49,9 @@ NoiseDHState *noise_handshakestate_get_remote_public_key_dh
     (const NoiseHandshakeState *state);
 NoiseDHState *noise_handshakestate_get_fixed_ephemeral_dh
     (NoiseHandshakeState *state);
+int noise_handshakestate_set_local_ephemeral
+    (NoiseHandshakeState *state, const uint8_t *private_key,
+     size_t private_key_len, const uint8_t *public_key, size_t public_key_len);
 NoiseDHState *noise_handshakestate_get_fixed_hybrid_dh
     (NoiseHandshakeState *state);
 int noise_handshakestate_needs_pre_shared_key(const NoiseHandshakeState *state);

--- a/src/protocol/dhstate.c
+++ b/src/protocol/dhstate.c
@@ -401,6 +401,51 @@ int noise_dhstate_set_keypair
 }
 
 /**
+ * \brief Sets the keypair within a DHState object without verifying it.
+ *
+ * \param state The DHState object.
+ * \param private_key Points to the private key.
+ * \param private_key_len Length of the private key in bytes.
+ * \param public_key Points to the public key.
+ * \param public_key_len Length of the public key in bytes.
+ *
+ * \return NOISE_ERROR_NONE on success.
+ * \return NOISE_ERROR_INVALID_PARAM if \a state, \a private_key or
+ * \a public_key is NULL.
+ * \return NOISE_ERROR_NOT_APPLICABLE if the algorithm derives its keys
+ * from the remote party's, as New Hope does.
+ * \return NOISE_ERROR_INVALID_LENGTH if a key length is wrong for the
+ * algorithm.
+ *
+ * Internal counterpart of noise_dhstate_set_keypair() that copies the two
+ * keys straight into the DHState's buffers instead of going through the
+ * backend's set_keypair hook, which recomputes the public key to check the
+ * pair. Only valid for backends whose entire key state is those two
+ * buffers, which every non ephemeral-only backend in this library
+ * satisfies; a backend that keeps more must not be used with it.
+ */
+int noise_dhstate_set_keypair_unchecked
+    (NoiseDHState *state, const uint8_t *private_key, size_t private_key_len,
+     const uint8_t *public_key, size_t public_key_len)
+{
+    /* Validate the parameters */
+    if (!state || !private_key || !public_key)
+        return NOISE_ERROR_INVALID_PARAM;
+    if (state->ephemeral_only)
+        return NOISE_ERROR_NOT_APPLICABLE;
+    if (private_key_len != state->private_key_len)
+        return NOISE_ERROR_INVALID_LENGTH;
+    if (public_key_len != state->public_key_len)
+        return NOISE_ERROR_INVALID_LENGTH;
+
+    /* Copy the keypair as is */
+    memcpy(state->private_key, private_key, private_key_len);
+    memcpy(state->public_key, public_key, public_key_len);
+    state->key_type = NOISE_KEY_TYPE_KEYPAIR;
+    return NOISE_ERROR_NONE;
+}
+
+/**
  * \brief Sets the keypair within a DHState object based on a private key only.
  *
  * \param state The DHState object.

--- a/src/protocol/handshakestate.c
+++ b/src/protocol/handshakestate.c
@@ -533,6 +533,10 @@ NoiseDHState *noise_handshakestate_get_fixed_ephemeral_dh
  * more than one handshake; the application should noise_clean() its own
  * copy once this function returns.
  *
+ * A fixed ephemeral key installed with
+ * noise_handshakestate_get_fixed_ephemeral_dh() takes precedence over a
+ * key pair supplied here; that hook exists for test vectors only.
+ *
  * \sa noise_handshakestate_get_fixed_ephemeral_dh()
  */
 int noise_handshakestate_set_local_ephemeral

--- a/src/protocol/handshakestate.c
+++ b/src/protocol/handshakestate.c
@@ -1138,7 +1138,6 @@ int noise_handshakestate_fallback_to(NoiseHandshakeState *state, const char *pat
         state->role = NOISE_ROLE_RESPONDER;
     } else {
         noise_dhstate_clear_key(state->dh_local_ephemeral);
-        state->local_ephemeral_supplied = 0;
         noise_dhstate_clear_key(state->dh_local_hybrid);
         if (!(flags & NOISE_PAT_FLAG_REMOTE_REQUIRED))
             noise_dhstate_clear_key(state->dh_remote_static);
@@ -1148,6 +1147,9 @@ int noise_handshakestate_fallback_to(NoiseHandshakeState *state, const char *pat
     /* Start a new token pattern for the fallback */
     memcpy(state->pattern, tokens, NOISE_MAX_TOKENS);
     state->tokens = state->pattern + 2;
+    /* The ephemeral either went out already or was just cleared; either
+       way no supplied key is pending any more */
+    state->local_ephemeral_supplied = 0;
     state->action = NOISE_ACTION_NONE;
 
     /* Set up the key requirements for the fallback */

--- a/src/protocol/handshakestate.c
+++ b/src/protocol/handshakestate.c
@@ -1306,14 +1306,14 @@ static int noise_handshakestate_write
                     (state->dh_local_ephemeral, state->dh_fixed_ephemeral,
                      state->dh_remote_ephemeral);
             }
-            /* Whichever source was used, the supplied key is consumed */
-            state->local_ephemeral_supplied = 0;
             if (err != NOISE_ERROR_NONE)
                 break;
             len = state->dh_local_ephemeral->public_key_len;
             if (rest.max_size < len)
                 return NOISE_ERROR_INVALID_LENGTH;
             memcpy(rest.data, state->dh_local_ephemeral->public_key, len);
+            /* The key, supplied or fixed, is on the wire now */
+            state->local_ephemeral_supplied = 0;
             noise_symmetricstate_mix_hash(state->symmetric, rest.data, len);
             if (state->requirements & NOISE_REQ_PSK) {
                 noise_symmetricstate_mix_key(state->symmetric, rest.data, len);

--- a/src/protocol/handshakestate.c
+++ b/src/protocol/handshakestate.c
@@ -1147,8 +1147,8 @@ int noise_handshakestate_fallback_to(NoiseHandshakeState *state, const char *pat
     /* Start a new token pattern for the fallback */
     memcpy(state->pattern, tokens, NOISE_MAX_TOKENS);
     state->tokens = state->pattern + 2;
-    /* The ephemeral either went out already or was just cleared; either
-       way no supplied key is pending any more */
+    /* No supplied key is pending any more: it was sent, cleared above, or
+       is abandoned with the failed attempt this fallback leaves behind */
     state->local_ephemeral_supplied = 0;
     state->action = NOISE_ACTION_NONE;
 

--- a/src/protocol/handshakestate.c
+++ b/src/protocol/handshakestate.c
@@ -513,8 +513,10 @@ NoiseDHState *noise_handshakestate_get_fixed_ephemeral_dh
  * \return NOISE_ERROR_NONE on success.
  * \return NOISE_ERROR_INVALID_PARAM if \a state, \a private_key or
  * \a public_key is NULL.
- * \return NOISE_ERROR_INVALID_STATE if the handshake has already started
- * or the pattern has no local ephemeral key.
+ * \return NOISE_ERROR_INVALID_STATE if the handshake has already started,
+ * if the pattern has no local ephemeral key, or if the local ephemeral key
+ * is already set: by an earlier call, or because the key was sent in a
+ * previous message and kept across noise_handshakestate_fallback().
  * \return NOISE_ERROR_NOT_APPLICABLE if the algorithm derives its
  * ephemeral key from the remote party's, as New Hope does.
  * \return NOISE_ERROR_INVALID_LENGTH if a key length is wrong for the
@@ -524,9 +526,12 @@ NoiseDHState *noise_handshakestate_get_fixed_ephemeral_dh
  * handshake on small devices.  This function lets the application generate
  * it ahead of time, off the latency critical path, and hand it to the
  * handshake instead of having noise_handshakestate_write_message()
- * generate it.  The key pair is copied as is and is not verified, so it
- * must come from the application's own generator and must never be
- * supplied to more than one handshake.
+ * generate it.  The key pair is copied as is and is not verified: a
+ * private key that does not match the public key makes the handshake fail
+ * later with NOISE_ERROR_MAC_FAILURE rather than here.  The key pair must
+ * come from the application's own generator and must never be supplied to
+ * more than one handshake; the application should noise_clean() its own
+ * copy once this function returns.
  *
  * \sa noise_handshakestate_get_fixed_ephemeral_dh()
  */
@@ -535,6 +540,7 @@ int noise_handshakestate_set_local_ephemeral
      size_t private_key_len, const uint8_t *public_key, size_t public_key_len)
 {
     NoiseDHState *dh;
+    int err;
 
     /* Validate the parameters */
     if (!state || !private_key || !public_key)
@@ -542,16 +548,15 @@ int noise_handshakestate_set_local_ephemeral
     dh = state->dh_local_ephemeral;
     if (!dh || state->action != NOISE_ACTION_NONE)
         return NOISE_ERROR_INVALID_STATE;
-    if (dh->ephemeral_only)
-        return NOISE_ERROR_NOT_APPLICABLE;
-    if (private_key_len != dh->private_key_len ||
-            public_key_len != dh->public_key_len)
-        return NOISE_ERROR_INVALID_LENGTH;
+    if (dh->key_type != NOISE_KEY_TYPE_NO_KEY)
+        return NOISE_ERROR_INVALID_STATE;
 
     /* Copy the key pair into the ephemeral DHState */
-    memcpy(dh->private_key, private_key, private_key_len);
-    memcpy(dh->public_key, public_key, public_key_len);
-    dh->key_type = NOISE_KEY_TYPE_KEYPAIR;
+    err = noise_dhstate_set_keypair_unchecked
+        (dh, private_key, private_key_len, public_key, public_key_len);
+    if (err != NOISE_ERROR_NONE)
+        return err;
+    state->local_ephemeral_supplied = 1;
     return NOISE_ERROR_NONE;
 }
 
@@ -1129,6 +1134,7 @@ int noise_handshakestate_fallback_to(NoiseHandshakeState *state, const char *pat
         state->role = NOISE_ROLE_RESPONDER;
     } else {
         noise_dhstate_clear_key(state->dh_local_ephemeral);
+        state->local_ephemeral_supplied = 0;
         noise_dhstate_clear_key(state->dh_local_hybrid);
         if (!(flags & NOISE_PAT_FLAG_REMOTE_REQUIRED))
             noise_dhstate_clear_key(state->dh_remote_static);
@@ -1282,12 +1288,12 @@ static int noise_handshakestate_write
             if (!state->dh_local_ephemeral)
                 return NOISE_ERROR_INVALID_STATE;
             if (!state->dh_fixed_ephemeral) {
-                if (state->dh_local_ephemeral->key_type !=
-                        NOISE_KEY_TYPE_KEYPAIR) {
+                if (!state->local_ephemeral_supplied) {
                     err = noise_dhstate_generate_dependent_keypair
                         (state->dh_local_ephemeral,
                          state->dh_remote_ephemeral);
                 }
+                state->local_ephemeral_supplied = 0;
             } else {
                 /* Use the fixed ephemeral key provided by the test harness.
                    To support New Hope we need to perform a dependent copy */

--- a/src/protocol/handshakestate.c
+++ b/src/protocol/handshakestate.c
@@ -1297,7 +1297,6 @@ static int noise_handshakestate_write
                         (state->dh_local_ephemeral,
                          state->dh_remote_ephemeral);
                 }
-                state->local_ephemeral_supplied = 0;
             } else {
                 /* Use the fixed ephemeral key provided by the test harness.
                    To support New Hope we need to perform a dependent copy */
@@ -1307,6 +1306,8 @@ static int noise_handshakestate_write
                     (state->dh_local_ephemeral, state->dh_fixed_ephemeral,
                      state->dh_remote_ephemeral);
             }
+            /* Whichever source was used, the supplied key is consumed */
+            state->local_ephemeral_supplied = 0;
             if (err != NOISE_ERROR_NONE)
                 break;
             len = state->dh_local_ephemeral->public_key_len;

--- a/src/protocol/handshakestate.c
+++ b/src/protocol/handshakestate.c
@@ -502,6 +502,60 @@ NoiseDHState *noise_handshakestate_get_fixed_ephemeral_dh
 }
 
 /**
+ * \brief Supplies a pre-generated ephemeral key pair for this handshake.
+ *
+ * \param state The HandshakeState object.
+ * \param private_key Points to the private key.
+ * \param private_key_len Length of the private key in bytes.
+ * \param public_key Points to the public key.
+ * \param public_key_len Length of the public key in bytes.
+ *
+ * \return NOISE_ERROR_NONE on success.
+ * \return NOISE_ERROR_INVALID_PARAM if \a state, \a private_key or
+ * \a public_key is NULL.
+ * \return NOISE_ERROR_INVALID_STATE if the handshake has already started
+ * or the pattern has no local ephemeral key.
+ * \return NOISE_ERROR_NOT_APPLICABLE if the algorithm derives its
+ * ephemeral key from the remote party's, as New Hope does.
+ * \return NOISE_ERROR_INVALID_LENGTH if a key length is wrong for the
+ * algorithm.
+ *
+ * Generating the ephemeral key pair is the most expensive step of a
+ * handshake on small devices.  This function lets the application generate
+ * it ahead of time, off the latency critical path, and hand it to the
+ * handshake instead of having noise_handshakestate_write_message()
+ * generate it.  The key pair is copied as is and is not verified, so it
+ * must come from the application's own generator and must never be
+ * supplied to more than one handshake.
+ *
+ * \sa noise_handshakestate_get_fixed_ephemeral_dh()
+ */
+int noise_handshakestate_set_local_ephemeral
+    (NoiseHandshakeState *state, const uint8_t *private_key,
+     size_t private_key_len, const uint8_t *public_key, size_t public_key_len)
+{
+    NoiseDHState *dh;
+
+    /* Validate the parameters */
+    if (!state || !private_key || !public_key)
+        return NOISE_ERROR_INVALID_PARAM;
+    dh = state->dh_local_ephemeral;
+    if (!dh || state->action != NOISE_ACTION_NONE)
+        return NOISE_ERROR_INVALID_STATE;
+    if (dh->ephemeral_only)
+        return NOISE_ERROR_NOT_APPLICABLE;
+    if (private_key_len != dh->private_key_len ||
+            public_key_len != dh->public_key_len)
+        return NOISE_ERROR_INVALID_LENGTH;
+
+    /* Copy the key pair into the ephemeral DHState */
+    memcpy(dh->private_key, private_key, private_key_len);
+    memcpy(dh->public_key, public_key, public_key_len);
+    dh->key_type = NOISE_KEY_TYPE_KEYPAIR;
+    return NOISE_ERROR_NONE;
+}
+
+/**
  * \brief Gets the DHState object that contains the local additional
  * hybrid secrecy keypair.
  *
@@ -1222,12 +1276,18 @@ static int noise_handshakestate_write
         case NOISE_TOKEN_E:
             /* Generate a local ephemeral keypair and add the public
                key to the message.  If we are running fixed vector tests,
-               then the ephemeral key may have already been provided. */
+               then the ephemeral key may have already been provided, and
+               the application may have supplied one ahead of time with
+               noise_handshakestate_set_local_ephemeral(). */
             if (!state->dh_local_ephemeral)
                 return NOISE_ERROR_INVALID_STATE;
             if (!state->dh_fixed_ephemeral) {
-                err = noise_dhstate_generate_dependent_keypair
-                    (state->dh_local_ephemeral, state->dh_remote_ephemeral);
+                if (state->dh_local_ephemeral->key_type !=
+                        NOISE_KEY_TYPE_KEYPAIR) {
+                    err = noise_dhstate_generate_dependent_keypair
+                        (state->dh_local_ephemeral,
+                         state->dh_remote_ephemeral);
+                }
             } else {
                 /* Use the fixed ephemeral key provided by the test harness.
                    To support New Hope we need to perform a dependent copy */

--- a/src/protocol/internal.h
+++ b/src/protocol/internal.h
@@ -550,6 +550,11 @@ struct NoiseHandshakeState_s
     /** \brief Next action to be taken by the application */
     int action;
 
+    /** \brief Non-zero if the application supplied the local ephemeral
+        key pair with noise_handshakestate_set_local_ephemeral() and the
+        "e" token has not consumed it yet */
+    uint8_t local_ephemeral_supplied : 1;
+
     /** \brief Expanded message pattern for the current handshake */
     uint8_t pattern[NOISE_MAX_TOKENS];
 
@@ -699,5 +704,9 @@ int noise_pattern_expand
 #ifdef __cplusplus
 };
 #endif
+
+int noise_dhstate_set_keypair_unchecked
+    (NoiseDHState *state, const uint8_t *private_key, size_t private_key_len,
+     const uint8_t *public_key, size_t public_key_len);
 
 #endif

--- a/src/protocol/internal.h
+++ b/src/protocol/internal.h
@@ -701,12 +701,12 @@ int noise_pattern_expand
     (uint8_t pattern[NOISE_MAX_TOKENS], int pattern_id,
      const int *modifiers, size_t num_modifiers);
 
-#ifdef __cplusplus
-};
-#endif
-
 int noise_dhstate_set_keypair_unchecked
     (NoiseDHState *state, const uint8_t *private_key, size_t private_key_len,
      const uint8_t *public_key, size_t public_key_len);
+
+#ifdef __cplusplus
+};
+#endif
 
 #endif

--- a/tests/unit/test-handshakestate.c
+++ b/tests/unit/test-handshakestate.c
@@ -432,7 +432,7 @@ static void handshakestate_check_protocols(void)
     check_handshake_protocol("Noise_K_25519_AESGCM_SHA256");
     check_handshake_protocol("Noise_X_448_AESGCM_SHA512");
 
-    check_handshake_protocol("Noise_NN_25519_ChaChaPoly_SHA256");
+    check_handshake_protocol("Noise_NN_25519_ChaChaPoly_BLAKE2s");
     check_handshake_protocol("Noise_NK_448_ChaChaPoly_BLAKE2b");
     check_handshake_protocol("Noise_NX_25519_AESGCM_BLAKE2b");
 
@@ -741,6 +741,11 @@ static void handshakestate_check_preset_ephemeral(void)
     compare(noise_handshakestate_set_local_ephemeral
                 (initiator, private_key, 32, public_key, 32),
             NOISE_ERROR_NONE);
+
+    /* A second key pair cannot replace the first */
+    compare(noise_handshakestate_set_local_ephemeral
+                (initiator, private_key, 32, public_key, 32),
+            NOISE_ERROR_INVALID_STATE);
     compare(noise_handshakestate_start(initiator), NOISE_ERROR_NONE);
     compare(noise_handshakestate_start(responder), NOISE_ERROR_NONE);
 
@@ -775,9 +780,11 @@ static void handshakestate_check_preset_ephemeral(void)
 
 void test_handshakestate(void)
 {
+    /* First: the checks below stop at the first algorithm this build
+       leaves out, and this one only needs Curve25519 */
+    handshakestate_check_preset_ephemeral();
     handshakestate_derive_keys();
     handshakestate_check_protocols();
     handshakestate_check_fallback();
-    handshakestate_check_preset_ephemeral();
     handshakestate_check_errors();
 }

--- a/tests/unit/test-handshakestate.c
+++ b/tests/unit/test-handshakestate.c
@@ -729,6 +729,14 @@ static void handshakestate_check_preset_ephemeral(void)
                 (initiator, private_key, 32, public_key, 33),
             NOISE_ERROR_INVALID_LENGTH);
 
+    /* Algorithms whose ephemeral key depends on the remote party's
+       (New Hope) cannot take a preset key pair; simulate one */
+    initiator->dh_local_ephemeral->ephemeral_only = 1;
+    compare(noise_handshakestate_set_local_ephemeral
+                (initiator, private_key, 32, public_key, 32),
+            NOISE_ERROR_NOT_APPLICABLE);
+    initiator->dh_local_ephemeral->ephemeral_only = 0;
+
     /* Supply the key pair to the initiator and run the handshake */
     compare(noise_handshakestate_set_local_ephemeral
                 (initiator, private_key, 32, public_key, 32),
@@ -755,7 +763,6 @@ static void handshakestate_check_preset_ephemeral(void)
     noise_buffer_set_output(mbuf, message, sizeof(message));
     compare(noise_handshakestate_write_message(responder, &mbuf, 0),
             NOISE_ERROR_NONE);
-    verify(memcmp(message, public_key, 32) != 0);
     noise_buffer_set_input(mbuf, message, mbuf.size);
     compare(noise_handshakestate_read_message(initiator, &mbuf, 0),
             NOISE_ERROR_NONE);

--- a/tests/unit/test-handshakestate.c
+++ b/tests/unit/test-handshakestate.c
@@ -432,7 +432,7 @@ static void handshakestate_check_protocols(void)
     check_handshake_protocol("Noise_K_25519_AESGCM_SHA256");
     check_handshake_protocol("Noise_X_448_AESGCM_SHA512");
 
-    check_handshake_protocol("Noise_NN_25519_ChaChaPoly_BLAKE2s");
+    check_handshake_protocol("Noise_NN_25519_ChaChaPoly_SHA256");
     check_handshake_protocol("Noise_NK_448_ChaChaPoly_BLAKE2b");
     check_handshake_protocol("Noise_NX_25519_AESGCM_BLAKE2b");
 
@@ -688,10 +688,89 @@ static void handshakestate_check_errors(void)
     verify(state == NULL);
 }
 
+/* Check that a key pair supplied ahead of time is used as the local
+   ephemeral key and that the handshake still completes */
+static void handshakestate_check_preset_ephemeral(void)
+{
+    NoiseHandshakeState *initiator;
+    NoiseHandshakeState *responder;
+    NoiseDHState *dh;
+    uint8_t private_key[32];
+    uint8_t public_key[32];
+    uint8_t message[256];
+    NoiseBuffer mbuf;
+
+    compare(noise_handshakestate_new_by_name
+                (&initiator, "Noise_NN_25519_ChaChaPoly_SHA256",
+                 NOISE_ROLE_INITIATOR), NOISE_ERROR_NONE);
+    compare(noise_handshakestate_new_by_name
+                (&responder, "Noise_NN_25519_ChaChaPoly_SHA256",
+                 NOISE_ROLE_RESPONDER), NOISE_ERROR_NONE);
+
+    /* Generate a key pair the way an application would */
+    compare(noise_dhstate_new_by_id(&dh, NOISE_DH_CURVE25519), NOISE_ERROR_NONE);
+    compare(noise_dhstate_generate_keypair(dh), NOISE_ERROR_NONE);
+    compare(noise_dhstate_get_keypair
+                (dh, private_key, sizeof(private_key),
+                 public_key, sizeof(public_key)), NOISE_ERROR_NONE);
+    noise_dhstate_free(dh);
+
+    /* Parameter checks */
+    compare(noise_handshakestate_set_local_ephemeral
+                (0, private_key, 32, public_key, 32),
+            NOISE_ERROR_INVALID_PARAM);
+    compare(noise_handshakestate_set_local_ephemeral
+                (initiator, 0, 32, public_key, 32),
+            NOISE_ERROR_INVALID_PARAM);
+    compare(noise_handshakestate_set_local_ephemeral
+                (initiator, private_key, 31, public_key, 32),
+            NOISE_ERROR_INVALID_LENGTH);
+    compare(noise_handshakestate_set_local_ephemeral
+                (initiator, private_key, 32, public_key, 33),
+            NOISE_ERROR_INVALID_LENGTH);
+
+    /* Supply the key pair to the initiator and run the handshake */
+    compare(noise_handshakestate_set_local_ephemeral
+                (initiator, private_key, 32, public_key, 32),
+            NOISE_ERROR_NONE);
+    compare(noise_handshakestate_start(initiator), NOISE_ERROR_NONE);
+    compare(noise_handshakestate_start(responder), NOISE_ERROR_NONE);
+
+    /* Too late once the handshake has started */
+    compare(noise_handshakestate_set_local_ephemeral
+                (initiator, private_key, 32, public_key, 32),
+            NOISE_ERROR_INVALID_STATE);
+
+    /* The first message must carry the supplied public key */
+    noise_buffer_set_output(mbuf, message, sizeof(message));
+    compare(noise_handshakestate_write_message(initiator, &mbuf, 0),
+            NOISE_ERROR_NONE);
+    verify(mbuf.size >= 32);
+    verify(!memcmp(message, public_key, 32));
+
+    /* The responder generates its own key and the handshake completes */
+    noise_buffer_set_input(mbuf, message, mbuf.size);
+    compare(noise_handshakestate_read_message(responder, &mbuf, 0),
+            NOISE_ERROR_NONE);
+    noise_buffer_set_output(mbuf, message, sizeof(message));
+    compare(noise_handshakestate_write_message(responder, &mbuf, 0),
+            NOISE_ERROR_NONE);
+    verify(memcmp(message, public_key, 32) != 0);
+    noise_buffer_set_input(mbuf, message, mbuf.size);
+    compare(noise_handshakestate_read_message(initiator, &mbuf, 0),
+            NOISE_ERROR_NONE);
+    compare(noise_handshakestate_get_action(initiator), NOISE_ACTION_SPLIT);
+    compare(noise_handshakestate_get_action(responder), NOISE_ACTION_SPLIT);
+
+    noise_handshakestate_free(initiator);
+    noise_handshakestate_free(responder);
+}
+
 void test_handshakestate(void)
 {
     handshakestate_derive_keys();
     handshakestate_check_protocols();
     handshakestate_check_fallback();
+    handshakestate_check_preset_ephemeral();
     handshakestate_check_errors();
 }

--- a/tests/unit/test-handshakestate.c
+++ b/tests/unit/test-handshakestate.c
@@ -690,10 +690,11 @@ static void handshakestate_check_errors(void)
 
 /* Check that a key pair supplied ahead of time is used as the local
    ephemeral key and that the handshake still completes */
-static void handshakestate_check_preset_ephemeral(void)
+void test_handshakestate_preset_ephemeral(void)
 {
     NoiseHandshakeState *initiator;
     NoiseHandshakeState *responder;
+    NoiseHandshakeState *one_way;
     NoiseDHState *dh;
     uint8_t private_key[32];
     uint8_t public_key[32];
@@ -728,6 +729,15 @@ static void handshakestate_check_preset_ephemeral(void)
     compare(noise_handshakestate_set_local_ephemeral
                 (initiator, private_key, 32, public_key, 33),
             NOISE_ERROR_INVALID_LENGTH);
+
+    /* A pattern with no local ephemeral refuses the key pair */
+    compare(noise_handshakestate_new_by_name
+                (&one_way, "Noise_N_25519_ChaChaPoly_SHA256",
+                 NOISE_ROLE_RESPONDER), NOISE_ERROR_NONE);
+    compare(noise_handshakestate_set_local_ephemeral
+                (one_way, private_key, 32, public_key, 32),
+            NOISE_ERROR_INVALID_STATE);
+    noise_handshakestate_free(one_way);
 
     /* Algorithms whose ephemeral key depends on the remote party's
        (New Hope) cannot take a preset key pair; simulate one */
@@ -780,9 +790,6 @@ static void handshakestate_check_preset_ephemeral(void)
 
 void test_handshakestate(void)
 {
-    /* First: the checks below stop at the first algorithm this build
-       leaves out, and this one only needs Curve25519 */
-    handshakestate_check_preset_ephemeral();
     handshakestate_derive_keys();
     handshakestate_check_protocols();
     handshakestate_check_fallback();

--- a/tests/unit/test-main.c
+++ b/tests/unit/test-main.c
@@ -44,6 +44,7 @@ int main(int argc, char *argv[])
     test(dhstate);
     test(errors);
     test(handshakestate);
+    test(handshakestate_preset_ephemeral);
     test(hashstate);
     test(names);
     test(patterns);


### PR DESCRIPTION
Adds a way for the application to hand the handshake an ephemeral key pair it generated ahead of time. The base point multiply behind the ephemeral key costs about 60 ms on an ESP8266 and today runs inside write_message() while the client waits; with this call the device can generate the key while idle and the handshake only pays for the DH.

The key pair is copied into the local ephemeral DHState through an internal unchecked setter in dhstate.c, the handshake records that it was supplied, and write_message() skips generation on that flag until the e token consumes it; the fixed ephemeral test hook keeps precedence. The copy is not verified, so callers must use their own generator and never reuse a key pair. Refused after start(), when the local ephemeral already holds a key (a second call, or the initiator side after fallback where the key was already sent), for dependent-key algorithms (New Hope), and on wrong key lengths. Covered by a new unit test, registered as its own entry in test-main.c, that runs an NN handshake with a supplied key, checks the message carries that public key, and checks every refusal. The fork's unit suite is not runnable as a whole (test-cipherstate.c no longer compiles and the handshake checks stop at the first algorithm this fork leaves out), so the new test was run on its own against the built library.

Needed by esphome for the spare ephemeral key work that pairs with esphome-libs/libsodium#36.
