### PR TITLE
Bump libsodium to 1.10021.6

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -2,4 +2,4 @@ description: noise-c
 version: "0.1.22"
 repository: https://github.com/esphome/noise-c.git
 dependencies:
-  esphome/libsodium: "1.10021.5"
+  esphome/libsodium: "1.10021.6"

--- a/library.json
+++ b/library.json
@@ -20,7 +20,7 @@
         {
             "owner": "esphome",
             "name": "libsodium",
-            "version": "1.10021.5"
+            "version": "1.10021.6"
         }
     ]
 }


### PR DESCRIPTION
Picks up libsodium 1.10021.6 (esphome-libs/libsodium#36), which makes X25519 about twice as fast on ESP8266 through a BearSSL m15 ladder and cheaper fe25519 products; the primitives noise-c calls are unchanged, so this is a dependency refresh only. Both manifests move together.