### PR TITLE
Bump libsodium to 1.10021.7

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -2,4 +2,4 @@ description: noise-c
 version: "0.1.24"
 repository: https://github.com/esphome/noise-c.git
 dependencies:
-  esphome/libsodium: "1.10021.6"
+  esphome/libsodium: "1.10021.7"

--- a/library.json
+++ b/library.json
@@ -20,7 +20,7 @@
         {
             "owner": "esphome",
             "name": "libsodium",
-            "version": "1.10021.6"
+            "version": "1.10021.7"
         }
     ]
 }


### PR DESCRIPTION
Picks up libsodium 1.10021.7 (esphome-libs/libsodium#38), which shrinks the Ed25519 base point table to 16 packed tables so key generation stops thrashing the flash cache: about 20 KB less flash on ESP8266, ESP32 and RP2040, and the base point multiply 2.2 times faster on ESP32. The primitives noise-c calls are unchanged, so this is a dependency refresh only. Both manifests move together.
