### PR TITLE
Bump libsodium to 1.10021.8

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -2,4 +2,4 @@ description: noise-c
 version: "0.1.25"
 repository: https://github.com/esphome/noise-c.git
 dependencies:
-  esphome/libsodium: "1.10021.7"
+  esphome/libsodium: "1.10021.8"

--- a/library.json
+++ b/library.json
@@ -20,7 +20,7 @@
         {
             "owner": "esphome",
             "name": "libsodium",
-            "version": "1.10021.7"
+            "version": "1.10021.8"
         }
     ]
 }


### PR DESCRIPTION
Picks up libsodium 1.10021.8 (esphome-libs/libsodium#39 and #40): the m15 X25519 ladder on the RP2040, which takes its DH from 85 to 68 ms, and inline Poly1305 products and block loads on the ESP8266, which take the per packet ChaCha20-Poly1305 cost down by a quarter. The primitives noise-c calls are unchanged, so this is a dependency refresh only. Both manifests move together.
