### PR TITLE
Add switches to leave the name tables and unused features out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,5 +44,11 @@ jobs:
         run: |
           cmake -S . -B build-lib -DNOISE_C_FIND_LIBSODIUM=ON -DCMAKE_C_COMPILER=${{ matrix.compiler }}
           cmake --build build-lib --parallel
+      - name: Build the library the way the microcontroller builds do, switches off
+        if: matrix.libsodium == 'system'
+        run: |
+          cmake -S . -B build-small -DNOISE_C_FIND_LIBSODIUM=ON -DCMAKE_C_COMPILER=${{ matrix.compiler }} \
+            -DCMAKE_C_FLAGS="-DNOISE_USE_PROTOCOL_NAME_TABLE=0 -DNOISE_USE_FALLBACK=0 -DNOISE_USE_HFS=0"
+          cmake --build build-small --parallel
       - name: Test
         run: ctest --test-dir build --output-on-failure --no-tests=error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,13 @@ jobs:
         run: |
           cmake -S . -B build-lib -DNOISE_C_FIND_LIBSODIUM=ON -DCMAKE_C_COMPILER=${{ matrix.compiler }}
           cmake --build build-lib --parallel
-      - name: Build the library the way the microcontroller builds do, switches off
-        if: matrix.libsodium == 'system'
+      - name: Test the way the microcontroller builds are configured, switches off
+        if: matrix.libsodium == 'fork'
         run: |
-          cmake -S . -B build-small -DNOISE_C_FIND_LIBSODIUM=ON -DCMAKE_C_COMPILER=${{ matrix.compiler }} \
+          cmake -S . -B build-small -DNOISE_C_BUILD_TESTS=ON -DCMAKE_C_COMPILER=${{ matrix.compiler }} \
             -DCMAKE_C_FLAGS="-DNOISE_USE_PROTOCOL_NAME_TABLE=0 -DNOISE_USE_FALLBACK=0 -DNOISE_USE_HFS=0"
           cmake --build build-small --parallel
+          # Only the tests that do not name protocols other than the one left
+          build-small/noise-c-test-unit small_build single_protocol cipherstate dhstate errors hashstate randstate
       - name: Test
         run: ctest --test-dir build --output-on-failure --no-tests=error

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ set(NOISE_C_SRCS
   "src/protocol/handshakestate.c"
   "src/protocol/hashstate.c"
   "src/protocol/internal.c"
+  "src/protocol/names-single.c"
   "src/protocol/names.c"
   "src/protocol/patterns.c"
   "src/protocol/rand_os.c"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ else()
       "tests/unit/test-patterns.c"
       "tests/unit/test-randstate.c"
       "tests/unit/test-single-protocol.c"
+      "tests/unit/test-small-build.c"
       "tests/unit/test-symmetricstate.c"
     )
     add_executable(noise-c-test-vector

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,7 @@ else()
       "tests/unit/test-names.c"
       "tests/unit/test-patterns.c"
       "tests/unit/test-randstate.c"
+      "tests/unit/test-single-protocol.c"
       "tests/unit/test-symmetricstate.c"
     )
     add_executable(noise-c-test-vector

--- a/README.md
+++ b/README.md
@@ -51,6 +51,33 @@ unit tests cover
 the algorithms this fork ships. The vector runner skips a vector naming an
 algorithm the build leaves out and reports how many it skipped.
 
+Size switches for microcontroller builds
+----------------------------------------
+
+Three macros in `include/noise/defines.h` trade features for flash and RAM.
+All three are on by default, so a build that says nothing gets the library it
+always had; define one as 0 to leave that feature out. ESPHome turns all three
+off, since it builds its handshake from algorithm ids and never names one.
+
+* `NOISE_USE_PROTOCOL_NAME_TABLE` keeps the tables that turn algorithm names
+  into ids and back. With it off, `noise_protocol_name_to_id` and
+  `noise_protocol_id_to_name` handle only `Noise_NNpsk0_25519_ChaChaPoly_SHA256`
+  and answer `NOISE_ERROR_UNKNOWN_ID` or `NOISE_ERROR_UNKNOWN_NAME` for
+  anything else. The rest of the name API stays, and a link with
+  `-ffunction-sections -fdata-sections -Wl,--gc-sections`, which the ESP-IDF and
+  Arduino builds pass, drops the tables along with whatever no longer reaches
+  them. Turning the tables off pins the build to that one protocol, pattern
+  included: the switches for AES, SHA512, the two BLAKE2 hashes, Curve448 and
+  NewHope must stay off, the ones for SHA256, ChaCha20-Poly1305 and Curve25519
+  must stay on, and `NOISE_USE_FALLBACK` must be off as well, since fallback
+  needs the XX patterns named. The build stops with an `#error` if any of them
+  says otherwise. `noise_handshakestate_new_by_id` likewise accepts only
+  `NNpsk0` in that build.
+* `NOISE_USE_FALLBACK` and `NOISE_USE_HFS` keep the "fallback" and "hfs" pattern
+  modifiers. With them off, a pattern that asks for one is rejected with
+  `NOISE_ERROR_UNKNOWN_NAME`, and `noise_handshakestate_fallback` and
+  `noise_handshakestate_fallback_to` return `NOISE_ERROR_NOT_APPLICABLE`.
+
 This fork is maintained by the [ESPHome](https://esphome.io) project. To report
 bugs, contribute, or suggest improvements to it, please open an issue or pull
 request on [esphome-libs/noise-c](https://github.com/esphome-libs/noise-c/issues).

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -1935,7 +1935,9 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             = NOISE_USE_PROTOCOL_NAME_TABLE=1 \
+                         NOISE_USE_FALLBACK=1 \
+                         NOISE_USE_HFS=1
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/include/noise/defines.h
+++ b/include/noise/defines.h
@@ -68,6 +68,24 @@
 #define NOISE_USE_SODIUM_RAND (NOISE_USE_LIBSODIUM && !NOISE_USE_CUSTOM_RAND)
 #endif
 
+/* Three switches for builds that want the library smaller, all on by default
+   so nothing changes unless the build asks. ESPHome turns them off. */
+
+/* Format protocol names from the id tables. Off, noise_protocol_id_to_name
+   knows the one protocol ESPHome speaks and the tables are left out, which
+   pins the build to that one set of algorithms. */
+#ifndef NOISE_USE_PROTOCOL_NAME_TABLE
+#define NOISE_USE_PROTOCOL_NAME_TABLE 1
+#endif
+
+/* The "fallback" and "hfs" pattern modifiers, which ESPHome never asks for */
+#ifndef NOISE_USE_FALLBACK
+#define NOISE_USE_FALLBACK 1
+#endif
+#ifndef NOISE_USE_HFS
+#define NOISE_USE_HFS 1
+#endif
+
 #if NOISE_USE_REFERENCE_BACKEND
 
 #ifndef NOISE_USE_REFERENCE_CHACHA

--- a/src/protocol/handshakestate.c
+++ b/src/protocol/handshakestate.c
@@ -1182,7 +1182,9 @@ int noise_handshakestate_fallback_to(NoiseHandshakeState *state, const char *pat
 
 int noise_handshakestate_fallback(NoiseHandshakeState *state)
 {
-    return noise_handshakestate_fallback_to(state, "XXfallback");
+    if (!state)
+        return NOISE_ERROR_INVALID_PARAM;
+    return NOISE_ERROR_NOT_APPLICABLE;
 }
 
 int noise_handshakestate_fallback_to(NoiseHandshakeState *state, const char *pattern)

--- a/src/protocol/handshakestate.c
+++ b/src/protocol/handshakestate.c
@@ -969,6 +969,7 @@ int noise_handshakestate_start(NoiseHandshakeState *state)
     return NOISE_ERROR_NONE;
 }
 
+#if NOISE_USE_FALLBACK
 /**
  * \brief Falls back to the "XXfallback" handshake pattern.
  *
@@ -1177,6 +1178,21 @@ int noise_handshakestate_fallback_to(NoiseHandshakeState *state, const char *pat
     /* Ready to go */
     return NOISE_ERROR_NONE;
 }
+#else /* !NOISE_USE_FALLBACK */
+
+int noise_handshakestate_fallback(NoiseHandshakeState *state)
+{
+    return noise_handshakestate_fallback_to(state, "XXfallback");
+}
+
+int noise_handshakestate_fallback_to(NoiseHandshakeState *state, const char *pattern)
+{
+    if (!state || !pattern)
+        return NOISE_ERROR_INVALID_PARAM;
+    return NOISE_ERROR_NOT_APPLICABLE;
+}
+
+#endif /* NOISE_USE_FALLBACK */
 
 /**
  * \brief Gets the next action the application should perform for

--- a/src/protocol/names-single.c
+++ b/src/protocol/names-single.c
@@ -92,13 +92,19 @@ int noise_protocol_id_to_name
     if (id->prefix_id != NOISE_PREFIX_STANDARD ||
             id->pattern_id != NOISE_PATTERN_NN ||
             id->modifier_ids[0] != NOISE_MODIFIER_PSK0 ||
-            id->modifier_ids[1] != NOISE_MODIFIER_NONE ||
             id->dh_id != NOISE_DH_CURVE25519 ||
             id->cipher_id != NOISE_CIPHER_CHACHAPOLY ||
             id->hash_id != NOISE_HASH_SHA256 ||
             id->hybrid_id != NOISE_DH_NONE) {
         *name = '\0';
         return NOISE_ERROR_UNKNOWN_ID;
+    }
+    /* psk0 is the only modifier; every other slot must be empty */
+    for (slot = 1; slot < NOISE_MAX_MODIFIER_IDS; ++slot) {
+        if (id->modifier_ids[slot] != NOISE_MODIFIER_NONE) {
+            *name = '\0';
+            return NOISE_ERROR_UNKNOWN_ID;
+        }
     }
     for (slot = 0; slot < sizeof(id->reserved) / sizeof(id->reserved[0]); ++slot) {
         if (id->reserved[slot]) {

--- a/src/protocol/names-single.c
+++ b/src/protocol/names-single.c
@@ -28,6 +28,16 @@
 
 #if !NOISE_USE_PROTOCOL_NAME_TABLE
 
+/* The tables are what let a build name any algorithm or pattern; without
+   them only the protocol below can be built, and the fallback modifier,
+   which needs the XX patterns named, goes with them */
+#if NOISE_USE_AES || NOISE_USE_SHA512 || NOISE_USE_BLAKE2S || \
+    NOISE_USE_BLAKE2B || NOISE_USE_CURVE448 || NOISE_USE_NEWHOPE || \
+    !NOISE_USE_SHA256 || !NOISE_USE_CHACHAPOLY || !NOISE_USE_CURVE25519 || \
+    NOISE_USE_FALLBACK
+#error "Without the name tables only Noise_NNpsk0_25519_ChaChaPoly_SHA256 can be built"
+#endif
+
 /* On the ESP8266 read only data sits in DRAM unless it is asked to live in
    flash, so the name is kept there and read through the pgmspace helpers.
    Everywhere else those are plain memcpy and memcmp. */

--- a/src/protocol/names-single.c
+++ b/src/protocol/names-single.c
@@ -41,13 +41,19 @@
 /* On the ESP8266 read only data sits in DRAM unless it is asked to live in
    flash, so the name is kept there and read through the pgmspace helpers.
    Everywhere else those are plain memcpy and memcmp. */
-#if (defined(ESP8266) || defined(ARDUINO_ARCH_ESP8266)) && \
-    defined(__has_include) && __has_include(<pgmspace.h>)
+#if defined(ESP8266) || defined(ARDUINO_ARCH_ESP8266)
+/* Nested on purpose: #if parses both sides of an &&, so a preprocessor
+   without __has_include cannot be spared by defined() in front of it */
+#ifdef __has_include
+#if __has_include(<pgmspace.h>)
 #include <pgmspace.h>
 #define NOISE_NAME_IN_FLASH PROGMEM
 #define noise_name_copy(dst, src, len) memcpy_P((dst), (src), (len))
 #define noise_name_cmp(str, name, len) memcmp_P((str), (name), (len))
-#else
+#endif
+#endif
+#endif
+#ifndef NOISE_NAME_IN_FLASH
 #define NOISE_NAME_IN_FLASH
 #define noise_name_copy(dst, src, len) memcpy((dst), (src), (len))
 #define noise_name_cmp(str, name, len) memcmp((str), (name), (len))

--- a/src/protocol/names-single.c
+++ b/src/protocol/names-single.c
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2016 Southern Storm Software, Pty Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+/* The protocol name functions for a build with the name tables switched off;
+   the tables and everything that walks them live in names.c. */
+
+#include "protocol/internal.h"
+#include <string.h>
+
+#if !NOISE_USE_PROTOCOL_NAME_TABLE
+
+/* On the ESP8266 read only data sits in DRAM unless it is asked to live in
+   flash, so the name is kept there and read through the pgmspace helpers.
+   Everywhere else those are plain memcpy and memcmp. */
+#if (defined(ESP8266) || defined(ARDUINO_ARCH_ESP8266)) && \
+    defined(__has_include) && __has_include(<pgmspace.h>)
+#include <pgmspace.h>
+#define NOISE_NAME_IN_FLASH PROGMEM
+#define noise_name_copy(dst, src, len) memcpy_P((dst), (src), (len))
+#define noise_name_cmp(str, name, len) memcmp_P((str), (name), (len))
+#else
+#define NOISE_NAME_IN_FLASH
+#define noise_name_copy(dst, src, len) memcpy((dst), (src), (len))
+#define noise_name_cmp(str, name, len) memcmp((str), (name), (len))
+#endif
+
+/* ESPHome speaks exactly one protocol, so its name is a constant. A shared
+   const NoiseProtocolId to compare against would cost more DRAM on the
+   ESP8266 than the field by field checks below cost in flash.
+
+   These answer as the table versions do for every id this build can name. An
+   id it cannot name, handed a buffer too small to hold any name, reports the
+   length rather than the id; the table version reports whichever it meets
+   first as it formats. Both fail, and both clear the buffer. */
+static const char noise_single_protocol_name[] NOISE_NAME_IN_FLASH =
+    "Noise_NNpsk0_25519_ChaChaPoly_SHA256";
+
+int noise_protocol_name_to_id
+    (NoiseProtocolId *id, const char *name, size_t name_len)
+{
+    if (!id || !name)
+        return NOISE_ERROR_INVALID_PARAM;
+    memset(id, 0, sizeof(NoiseProtocolId));
+    if (name_len != sizeof(noise_single_protocol_name) - 1 ||
+            noise_name_cmp(name, noise_single_protocol_name, name_len) != 0)
+        return NOISE_ERROR_UNKNOWN_NAME;
+    id->prefix_id = NOISE_PREFIX_STANDARD;
+    id->pattern_id = NOISE_PATTERN_NN;
+    id->modifier_ids[0] = NOISE_MODIFIER_PSK0;
+    id->dh_id = NOISE_DH_CURVE25519;
+    id->cipher_id = NOISE_CIPHER_CHACHAPOLY;
+    id->hash_id = NOISE_HASH_SHA256;
+    return NOISE_ERROR_NONE;
+}
+
+int noise_protocol_id_to_name
+    (char *name, size_t name_len, const NoiseProtocolId *id)
+{
+    size_t slot;
+
+    if (!id) {
+        if (name && name_len)
+            *name = '\0';
+        return NOISE_ERROR_INVALID_PARAM;
+    }
+    if (!name)
+        return NOISE_ERROR_INVALID_PARAM;
+    if (name_len < sizeof(noise_single_protocol_name)) {
+        if (name_len)
+            *name = '\0';
+        return NOISE_ERROR_INVALID_LENGTH;
+    }
+    if (id->prefix_id != NOISE_PREFIX_STANDARD ||
+            id->pattern_id != NOISE_PATTERN_NN ||
+            id->modifier_ids[0] != NOISE_MODIFIER_PSK0 ||
+            id->modifier_ids[1] != NOISE_MODIFIER_NONE ||
+            id->dh_id != NOISE_DH_CURVE25519 ||
+            id->cipher_id != NOISE_CIPHER_CHACHAPOLY ||
+            id->hash_id != NOISE_HASH_SHA256 ||
+            id->hybrid_id != NOISE_DH_NONE) {
+        *name = '\0';
+        return NOISE_ERROR_UNKNOWN_ID;
+    }
+    for (slot = 0; slot < sizeof(id->reserved) / sizeof(id->reserved[0]); ++slot) {
+        if (id->reserved[slot]) {
+            *name = '\0';
+            return NOISE_ERROR_UNKNOWN_ID;
+        }
+    }
+    noise_name_copy(name, noise_single_protocol_name,
+                    sizeof(noise_single_protocol_name));
+    return NOISE_ERROR_NONE;
+}
+
+#endif /* !NOISE_USE_PROTOCOL_NAME_TABLE */

--- a/src/protocol/names-single.c
+++ b/src/protocol/names-single.c
@@ -30,12 +30,15 @@
 
 /* The tables are what let a build name any algorithm or pattern; without
    them only the protocol below can be built, and the fallback modifier,
-   which needs the XX patterns named, goes with them */
+   which needs the XX patterns named, goes with them. A test that compiles
+   this file inside a full build defines NOISE_NAMES_SINGLE_UNGUARDED. */
+#ifndef NOISE_NAMES_SINGLE_UNGUARDED
 #if NOISE_USE_AES || NOISE_USE_SHA512 || NOISE_USE_BLAKE2S || \
     NOISE_USE_BLAKE2B || NOISE_USE_CURVE448 || NOISE_USE_NEWHOPE || \
     !NOISE_USE_SHA256 || !NOISE_USE_CHACHAPOLY || !NOISE_USE_CURVE25519 || \
     NOISE_USE_FALLBACK
 #error "Without the name tables only Noise_NNpsk0_25519_ChaChaPoly_SHA256 can be built"
+#endif
 #endif
 
 /* On the ESP8266 read only data sits in DRAM unless it is asked to live in

--- a/src/protocol/names.c
+++ b/src/protocol/names.c
@@ -411,17 +411,6 @@ int noise_ids_to_name_list(char *name, size_t name_len,
     return NOISE_ERROR_NONE;
 }
 
-/* The tables are what let a build name any algorithm or pattern; without
-   them only the one protocol names-single.c knows can be built, and the
-   fallback modifier, which needs the XX patterns named, goes with them */
-#if !NOISE_USE_PROTOCOL_NAME_TABLE && \
-    (NOISE_USE_AES || NOISE_USE_SHA512 || NOISE_USE_BLAKE2S || \
-     NOISE_USE_BLAKE2B || NOISE_USE_CURVE448 || NOISE_USE_NEWHOPE || \
-     !NOISE_USE_SHA256 || !NOISE_USE_CHACHAPOLY || !NOISE_USE_CURVE25519 || \
-     NOISE_USE_FALLBACK)
-#error "Without the name tables only Noise_NNpsk0_25519_ChaChaPoly_SHA256 can be built"
-#endif
-
 #if NOISE_USE_PROTOCOL_NAME_TABLE
 
 /**

--- a/src/protocol/names.c
+++ b/src/protocol/names.c
@@ -105,8 +105,12 @@ static NoiseIdMapping const algorithm_names[] = {
     {NOISE_PATTERN_IX,          "IX",            2},
 
     /* Handshake pattern modifiers */
+#if NOISE_USE_FALLBACK
     {NOISE_MODIFIER_FALLBACK,   "fallback",      8},
+#endif
+#if NOISE_USE_HFS
     {NOISE_MODIFIER_HFS,        "hfs",           3},
+#endif
     {NOISE_MODIFIER_PSK0,       "psk0",          4},
     {NOISE_MODIFIER_PSK1,       "psk1",          4},
     {NOISE_MODIFIER_PSK2,       "psk2",          4},
@@ -406,6 +410,19 @@ int noise_ids_to_name_list(char *name, size_t name_len,
     }
     return NOISE_ERROR_NONE;
 }
+
+/* The tables are what let a build name any algorithm or pattern; without
+   them only the one protocol names-single.c knows can be built, and the
+   fallback modifier, which needs the XX patterns named, goes with them */
+#if !NOISE_USE_PROTOCOL_NAME_TABLE && \
+    (NOISE_USE_AES || NOISE_USE_SHA512 || NOISE_USE_BLAKE2S || \
+     NOISE_USE_BLAKE2B || NOISE_USE_CURVE448 || NOISE_USE_NEWHOPE || \
+     !NOISE_USE_SHA256 || !NOISE_USE_CHACHAPOLY || !NOISE_USE_CURVE25519 || \
+     NOISE_USE_FALLBACK)
+#error "Without the name tables only Noise_NNpsk0_25519_ChaChaPoly_SHA256 can be built"
+#endif
+
+#if NOISE_USE_PROTOCOL_NAME_TABLE
 
 /**
  * \brief Parses a field from a protocol name string.
@@ -760,5 +777,7 @@ int noise_protocol_id_to_name
     /* Done */
     return err;
 }
+
+#endif /* NOISE_USE_PROTOCOL_NAME_TABLE */
 
 /**@}*/

--- a/src/protocol/patterns.c
+++ b/src/protocol/patterns.c
@@ -504,6 +504,7 @@ static int noise_pattern_put_token(int err, uint8_t output[NOISE_MAX_TOKENS],
     return NOISE_ERROR_NONE;
 }
 
+#if NOISE_USE_FALLBACK
 /**
  * \brief Expands a pattern using the "fallback" modifier.
  */
@@ -562,6 +563,9 @@ int noise_pattern_expand_fallback
     return noise_pattern_put_token(err, output, &out, NOISE_TOKEN_END);
 }
 
+#endif /* NOISE_USE_FALLBACK */
+
+#if NOISE_USE_HFS
 /**
  * \brief Expands a pattern using the "hfs" modifier.
  */
@@ -603,6 +607,8 @@ int noise_pattern_expand_hfs
         *flags |= NOISE_PAT_FLAG_REMOTE_HYBRID_REQ;
     return err;
 }
+
+#endif /* NOISE_USE_HFS */
 
 /**
  * \brief Expands a pattern using a "pskN" modifier.
@@ -704,12 +710,16 @@ int noise_pattern_expand
     for (index = 0; index < num_modifiers &&
                     err == NOISE_ERROR_NONE; ++index) {
         switch (modifiers[index]) {
+#if NOISE_USE_FALLBACK
         case NOISE_MODIFIER_FALLBACK:
             err = noise_pattern_expand_fallback(temp, pattern, &flags);
             break;
+#endif
+#if NOISE_USE_HFS
         case NOISE_MODIFIER_HFS:
             err = noise_pattern_expand_hfs(temp, pattern, &flags);
             break;
+#endif
         case NOISE_MODIFIER_PSK0:
         case NOISE_MODIFIER_PSK1:
         case NOISE_MODIFIER_PSK2:

--- a/tests/unit/test-main.c
+++ b/tests/unit/test-main.c
@@ -28,6 +28,27 @@ jmp_buf test_jump_back;
 const char *data_name = 0;
 int verbose = 0;
 
+/* True when the test was named on the command line, or none were */
+static int test_selected(int argc, char *argv[], const char *name)
+{
+    int index;
+    int any = 0;
+    for (index = 1; index < argc; ++index) {
+        if (!strcmp(argv[index], "--verbose"))
+            continue;
+        any = 1;
+        if (!strcmp(argv[index], name))
+            return 1;
+    }
+    return !any;
+}
+
+#define run(func) \
+    do { \
+        if (test_selected(argc, argv, #func)) \
+            test(func); \
+    } while (0)
+
 int main(int argc, char *argv[])
 {
     /* Parse the command-line arguments */
@@ -40,17 +61,18 @@ int main(int argc, char *argv[])
     }
 
     /* Run all tests */
-    test(cipherstate);
-    test(dhstate);
-    test(errors);
-    test(handshakestate);
-    test(handshakestate_preset_ephemeral);
-    test(hashstate);
-    test(names);
-    test(patterns);
-    test(randstate);
-    test(single_protocol);
-    test(symmetricstate);
+    run(cipherstate);
+    run(dhstate);
+    run(errors);
+    run(handshakestate);
+    run(handshakestate_preset_ephemeral);
+    run(hashstate);
+    run(names);
+    run(patterns);
+    run(randstate);
+    run(single_protocol);
+    run(small_build);
+    run(symmetricstate);
 
     /* Report the results */
     if (!test_failures) {

--- a/tests/unit/test-main.c
+++ b/tests/unit/test-main.c
@@ -51,9 +51,12 @@ static int test_selected(int argc, char *argv[], const char *name)
 
 int main(int argc, char *argv[])
 {
-    /* Parse the command-line arguments */
-    if (argc > 1 && !strcmp(argv[1], "--verbose"))
-        verbose = 1;
+    /* Parse the command-line arguments; --verbose may sit anywhere */
+    int index;
+    for (index = 1; index < argc; ++index) {
+        if (!strcmp(argv[index], "--verbose"))
+            verbose = 1;
+    }
 
     if (noise_init_framework() != NOISE_ERROR_NONE) {
         fprintf(stderr, "Noise initialization failed\n");

--- a/tests/unit/test-main.c
+++ b/tests/unit/test-main.c
@@ -87,18 +87,18 @@ int main(int argc, char *argv[])
     run(small_build);
     run(symmetricstate);
 
-    /* Report the results; every name given must have been a test */
+    /* Report the results; every name given must have been a test, and a
+       stale name is reported alongside the failures rather than instead */
     if (names_matched < names_given) {
         fprintf(stderr, "%d of the names given matched no test\n",
                 names_given - names_matched);
-        return 1;
     }
     if (!test_failures) {
         printf("All tests succeeded\n");
     } else {
         printf("%d test%s failed\n", test_failures, test_failures == 1 ? "" : "s");
     }
-    return test_failures ? 1 : 0;
+    return (test_failures || names_matched < names_given) ? 1 : 0;
 }
 
 static int from_hex(char ch)

--- a/tests/unit/test-main.c
+++ b/tests/unit/test-main.c
@@ -49,6 +49,7 @@ int main(int argc, char *argv[])
     test(names);
     test(patterns);
     test(randstate);
+    test(single_protocol);
     test(symmetricstate);
 
     /* Report the results */

--- a/tests/unit/test-main.c
+++ b/tests/unit/test-main.c
@@ -78,6 +78,10 @@ int main(int argc, char *argv[])
     run(symmetricstate);
 
     /* Report the results */
+    if (!test_count) {
+        fprintf(stderr, "no test matched the names given\n");
+        return 1;
+    }
     if (!test_failures) {
         printf("All tests succeeded\n");
     } else {

--- a/tests/unit/test-main.c
+++ b/tests/unit/test-main.c
@@ -28,6 +28,10 @@ jmp_buf test_jump_back;
 const char *data_name = 0;
 int verbose = 0;
 
+/* Names given on the command line, and which of them matched a test */
+static int names_given = 0;
+static int names_matched = 0;
+
 /* True when the test was named on the command line, or none were */
 static int test_selected(int argc, char *argv[], const char *name)
 {
@@ -37,8 +41,10 @@ static int test_selected(int argc, char *argv[], const char *name)
         if (!strcmp(argv[index], "--verbose"))
             continue;
         any = 1;
-        if (!strcmp(argv[index], name))
+        if (!strcmp(argv[index], name)) {
+            ++names_matched;
             return 1;
+        }
     }
     return !any;
 }
@@ -56,6 +62,8 @@ int main(int argc, char *argv[])
     for (index = 1; index < argc; ++index) {
         if (!strcmp(argv[index], "--verbose"))
             verbose = 1;
+        else
+            ++names_given;
     }
 
     if (noise_init_framework() != NOISE_ERROR_NONE) {
@@ -77,9 +85,10 @@ int main(int argc, char *argv[])
     run(small_build);
     run(symmetricstate);
 
-    /* Report the results */
-    if (!test_count) {
-        fprintf(stderr, "no test matched the names given\n");
+    /* Report the results; every name given must have been a test */
+    if (names_matched < names_given) {
+        fprintf(stderr, "%d of the names given matched no test\n",
+                names_given - names_matched);
         return 1;
     }
     if (!test_failures) {

--- a/tests/unit/test-main.c
+++ b/tests/unit/test-main.c
@@ -37,16 +37,18 @@ static int test_selected(int argc, char *argv[], const char *name)
 {
     int index;
     int any = 0;
+    int selected = 0;
     for (index = 1; index < argc; ++index) {
         if (!strcmp(argv[index], "--verbose"))
             continue;
         any = 1;
+        /* Every occurrence counts, so a name given twice is not stale */
         if (!strcmp(argv[index], name)) {
             ++names_matched;
-            return 1;
+            selected = 1;
         }
     }
-    return !any;
+    return any ? selected : 1;
 }
 
 #define run(func) \

--- a/tests/unit/test-single-protocol.c
+++ b/tests/unit/test-single-protocol.c
@@ -26,9 +26,13 @@
 
 #include "test-helpers.h"
 
-/* The reduced implementations, built a second time under the names below */
+/* The reduced implementations, built a second time under the names below.
+   Its configuration guard wants fallback off as well, as the small build
+   has it; that changes nothing else in this file */
 #undef NOISE_USE_PROTOCOL_NAME_TABLE
 #define NOISE_USE_PROTOCOL_NAME_TABLE 0
+#undef NOISE_USE_FALLBACK
+#define NOISE_USE_FALLBACK 0
 #define noise_protocol_id_to_name single_id_to_name
 #define noise_protocol_name_to_id single_name_to_id
 #include "protocol/names-single.c"

--- a/tests/unit/test-single-protocol.c
+++ b/tests/unit/test-single-protocol.c
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2016 Southern Storm Software, Pty Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+/* Builds the single protocol name functions a second time, under the names
+ * below, and checks they answer exactly as the table versions do. The name
+ * they return is hashed into the handshake, so the two must not drift. */
+
+#include "test-helpers.h"
+
+/* The reduced implementations, built a second time under the names below */
+#undef NOISE_USE_PROTOCOL_NAME_TABLE
+#define NOISE_USE_PROTOCOL_NAME_TABLE 0
+#define noise_protocol_id_to_name single_id_to_name
+#define noise_protocol_name_to_id single_name_to_id
+#include "protocol/names-single.c"
+#undef noise_protocol_id_to_name
+#undef noise_protocol_name_to_id
+
+/* On the protocol ESPHome speaks, the two must answer identically */
+static void compare_id_to_name(const NoiseProtocolId *id)
+{
+    char table_name[NOISE_MAX_PROTOCOL_NAME];
+    char single_name[NOISE_MAX_PROTOCOL_NAME];
+    int table_err, single_err;
+
+    memset(table_name, 0xAA, sizeof(table_name));
+    memset(single_name, 0x55, sizeof(single_name));
+    table_err = noise_protocol_id_to_name
+        (table_name, sizeof(table_name), id);
+    single_err = single_id_to_name(single_name, sizeof(single_name), id);
+    compare(single_err, table_err);
+    verify(!strcmp(single_name, table_name));
+}
+
+static void compare_name_to_id(const char *name)
+{
+    NoiseProtocolId table_id;
+    NoiseProtocolId single_id;
+    int table_err, single_err;
+
+    table_err = noise_protocol_name_to_id(&table_id, name, strlen(name));
+    single_err = single_name_to_id(&single_id, name, strlen(name));
+    compare(single_err, table_err);
+    verify(!memcmp(&single_id, &table_id, sizeof(NoiseProtocolId)));
+}
+
+/* An id the table can format but this build does not support */
+static void expect_unknown_id(const NoiseProtocolId *id)
+{
+    char name[NOISE_MAX_PROTOCOL_NAME];
+
+    compare(single_id_to_name(name, sizeof(name), id), NOISE_ERROR_UNKNOWN_ID);
+    verify(name[0] == '\0');
+}
+
+void test_single_protocol(void)
+{
+    NoiseProtocolId id;
+    char name[NOISE_MAX_PROTOCOL_NAME];
+
+    /* The protocol ESPHome speaks, which both versions must format the same */
+    memset(&id, 0, sizeof(id));
+    id.prefix_id = NOISE_PREFIX_STANDARD;
+    id.pattern_id = NOISE_PATTERN_NN;
+    id.modifier_ids[0] = NOISE_MODIFIER_PSK0;
+    id.dh_id = NOISE_DH_CURVE25519;
+    id.cipher_id = NOISE_CIPHER_CHACHAPOLY;
+    id.hash_id = NOISE_HASH_SHA256;
+    compare_id_to_name(&id);
+    compare(single_id_to_name(name, sizeof(name), &id), NOISE_ERROR_NONE);
+    verify(!strcmp(name, "Noise_NNpsk0_25519_ChaChaPoly_SHA256"));
+    compare_name_to_id("Noise_NNpsk0_25519_ChaChaPoly_SHA256");
+
+    /* Real protocols this build does not carry, one field at a time */
+    id.prefix_id = NOISE_PREFIX_NONE;
+    compare_id_to_name(&id);
+    id.prefix_id = NOISE_PREFIX_STANDARD;
+    id.pattern_id = NOISE_PATTERN_XX;
+    expect_unknown_id(&id);
+    id.pattern_id = NOISE_PATTERN_NN;
+    id.modifier_ids[0] = NOISE_MODIFIER_NONE;
+    expect_unknown_id(&id);
+    id.modifier_ids[0] = NOISE_MODIFIER_PSK0;
+    id.modifier_ids[1] = NOISE_MODIFIER_PSK1;
+    expect_unknown_id(&id);
+    id.modifier_ids[1] = NOISE_MODIFIER_NONE;
+    id.hybrid_id = NOISE_DH_CURVE25519;
+    expect_unknown_id(&id);
+    id.hybrid_id = NOISE_DH_NONE;
+    for (size_t slot = 0; slot < sizeof(id.reserved) / sizeof(id.reserved[0]); slot++) {
+        id.reserved[slot] = 1;
+        expect_unknown_id(&id);
+        id.reserved[slot] = 0;
+    }
+
+    /* Ids the table rejects too, where the error must match */
+    id.hash_id = NOISE_HASH_NONE;
+    compare_id_to_name(&id);
+    id.hash_id = NOISE_HASH_SHA256;
+    id.cipher_id = NOISE_CIPHER_NONE;
+    compare_id_to_name(&id);
+    id.cipher_id = NOISE_CIPHER_CHACHAPOLY;
+    id.dh_id = NOISE_DH_NONE;
+    compare_id_to_name(&id);
+    id.dh_id = NOISE_DH_CURVE25519;
+
+    /* Bad parameters, which both versions treat alike */
+    compare_id_to_name(0);
+    compare(single_id_to_name(0, sizeof(name), &id), NOISE_ERROR_INVALID_PARAM);
+    compare(single_id_to_name(name, 4, &id), NOISE_ERROR_INVALID_LENGTH);
+    verify(name[0] == '\0');
+    /* A buffer too small for any name is reported as the length, whatever
+       the id says; the table version may reach the id first */
+    id.pattern_id = NOISE_PATTERN_XX;
+    compare(single_id_to_name(name, 4, &id), NOISE_ERROR_INVALID_LENGTH);
+    id.pattern_id = NOISE_PATTERN_NN;
+    /* A zero length buffer must not be written to at all */
+    name[0] = 'x';
+    compare(single_id_to_name(name, 0, &id), NOISE_ERROR_INVALID_LENGTH);
+    verify(name[0] == 'x');
+    compare(single_name_to_id(0, "Noise_NNpsk0_25519_ChaChaPoly_SHA256", 36),
+            NOISE_ERROR_INVALID_PARAM);
+    compare(single_name_to_id(&id, 0, 0), NOISE_ERROR_INVALID_PARAM);
+
+    /* Names for other protocols, and for nothing at all */
+    compare_name_to_id("");
+    compare_name_to_id("Noise_NNpsk0_25519_ChaChaPoly_SHA256 ");
+    compare(single_name_to_id(&id, "Noise_XX_25519_ChaChaPoly_SHA256",
+                              strlen("Noise_XX_25519_ChaChaPoly_SHA256")),
+            NOISE_ERROR_UNKNOWN_NAME);
+}

--- a/tests/unit/test-single-protocol.c
+++ b/tests/unit/test-single-protocol.c
@@ -100,9 +100,11 @@ void test_single_protocol(void)
     id.modifier_ids[0] = NOISE_MODIFIER_NONE;
     expect_unknown_id(&id);
     id.modifier_ids[0] = NOISE_MODIFIER_PSK0;
-    id.modifier_ids[1] = NOISE_MODIFIER_PSK1;
-    expect_unknown_id(&id);
-    id.modifier_ids[1] = NOISE_MODIFIER_NONE;
+    for (size_t slot = 1; slot < NOISE_MAX_MODIFIER_IDS; slot++) {
+        id.modifier_ids[slot] = NOISE_MODIFIER_PSK1;
+        expect_unknown_id(&id);
+        id.modifier_ids[slot] = NOISE_MODIFIER_NONE;
+    }
     id.hybrid_id = NOISE_DH_CURVE25519;
     expect_unknown_id(&id);
     id.hybrid_id = NOISE_DH_NONE;

--- a/tests/unit/test-single-protocol.c
+++ b/tests/unit/test-single-protocol.c
@@ -26,13 +26,11 @@
 
 #include "test-helpers.h"
 
-/* The reduced implementations, built a second time under the names below.
-   Its configuration guard wants fallback off as well, as the small build
-   has it; that changes nothing else in this file */
+/* The reduced implementations, built a second time under the names below,
+   inside a full build its configuration guard would otherwise refuse */
 #undef NOISE_USE_PROTOCOL_NAME_TABLE
 #define NOISE_USE_PROTOCOL_NAME_TABLE 0
-#undef NOISE_USE_FALLBACK
-#define NOISE_USE_FALLBACK 0
+#define NOISE_NAMES_SINGLE_UNGUARDED
 #define noise_protocol_id_to_name single_id_to_name
 #define noise_protocol_name_to_id single_name_to_id
 #include "protocol/names-single.c"

--- a/tests/unit/test-single-protocol.c
+++ b/tests/unit/test-single-protocol.c
@@ -51,6 +51,19 @@ static void compare_id_to_name(const NoiseProtocolId *id)
     verify(!strcmp(single_name, table_name));
 }
 
+/* The same, with a buffer of the given length, where the exact fit and one
+   short of it must be judged alike */
+static void compare_id_to_name_len(const NoiseProtocolId *id, size_t len)
+{
+    char table_name[NOISE_MAX_PROTOCOL_NAME];
+    char single_name[NOISE_MAX_PROTOCOL_NAME];
+    int table_err = noise_protocol_id_to_name(table_name, len, id);
+    int single_err = single_id_to_name(single_name, len, id);
+    compare(single_err, table_err);
+    if (table_err == NOISE_ERROR_NONE)
+        verify(!strcmp(single_name, table_name));
+}
+
 static void compare_name_to_id(const char *name)
 {
     NoiseProtocolId table_id;
@@ -124,6 +137,11 @@ void test_single_protocol(void)
     id.dh_id = NOISE_DH_NONE;
     compare_id_to_name(&id);
     id.dh_id = NOISE_DH_CURVE25519;
+
+    /* The name is 36 characters: a 37 byte buffer fits, a 36 byte one does
+       not, and both versions must say so */
+    compare_id_to_name_len(&id, 37);
+    compare_id_to_name_len(&id, 36);
 
     /* Bad parameters, which both versions treat alike */
     compare_id_to_name(0);

--- a/tests/unit/test-small-build.c
+++ b/tests/unit/test-small-build.c
@@ -21,6 +21,7 @@
  */
 
 #include "test-helpers.h"
+#include "protocol/internal.h"
 
 /* What the library promises once the size switches are off, which is the
    configuration every microcontroller build uses; with the switches on
@@ -77,11 +78,16 @@ void test_small_build(void)
 #endif
 
 #if !NOISE_USE_HFS
-    /* A pattern that asks for hybrid forward secrecy is unknown */
+    /* The hfs modifier is unknown to the pattern expander itself, not
+       only to a name parser that may have no tables */
     {
-        static const char hfs[] = "Noise_NNhfs_25519+NewHope_ChaChaPoly_SHA256";
-        compare(noise_protocol_name_to_id(&id, hfs, strlen(hfs)),
+        uint8_t pattern[NOISE_MAX_TOKENS];
+        int modifier = NOISE_MODIFIER_HFS;
+        compare(noise_pattern_expand(pattern, NOISE_PATTERN_NN, &modifier, 1),
                 NOISE_ERROR_UNKNOWN_NAME);
+        modifier = NOISE_MODIFIER_PSK0;
+        compare(noise_pattern_expand(pattern, NOISE_PATTERN_NN, &modifier, 1),
+                NOISE_ERROR_NONE);
     }
 #endif
 

--- a/tests/unit/test-small-build.c
+++ b/tests/unit/test-small-build.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2026 ESPHome
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include "test-helpers.h"
+
+/* What the library promises once the size switches are off, which is the
+   configuration every microcontroller build uses; with the switches on
+   there is nothing here to check */
+void test_small_build(void)
+{
+    static const char single[] = "Noise_NNpsk0_25519_ChaChaPoly_SHA256";
+    NoiseHandshakeState *state = 0;
+    NoiseProtocolId id;
+
+#if !NOISE_USE_PROTOCOL_NAME_TABLE
+    /* The one protocol still works by name and by id */
+    compare(noise_handshakestate_new_by_name
+                (&state, single, NOISE_ROLE_INITIATOR),
+            NOISE_ERROR_NONE);
+    compare(noise_handshakestate_get_protocol_id(state, &id),
+            NOISE_ERROR_NONE);
+    compare(noise_handshakestate_free(state), NOISE_ERROR_NONE);
+    compare(noise_handshakestate_new_by_id
+                (&state, &id, NOISE_ROLE_RESPONDER),
+            NOISE_ERROR_NONE);
+    compare(noise_handshakestate_free(state), NOISE_ERROR_NONE);
+
+    /* Every other protocol is unknown, and the out parameter is cleared */
+    state = (NoiseHandshakeState *)8;
+    compare(noise_handshakestate_new_by_name
+                (&state, "Noise_XX_25519_ChaChaPoly_SHA256",
+                 NOISE_ROLE_INITIATOR),
+            NOISE_ERROR_UNKNOWN_NAME);
+    verify(state == NULL);
+    id.pattern_id = NOISE_PATTERN_XX;
+    id.modifier_ids[0] = NOISE_MODIFIER_NONE;
+    state = (NoiseHandshakeState *)8;
+    compare(noise_handshakestate_new_by_id
+                (&state, &id, NOISE_ROLE_INITIATOR),
+            NOISE_ERROR_UNKNOWN_ID);
+    verify(state == NULL);
+#endif
+
+#if !NOISE_USE_FALLBACK
+    /* Fallback is refused rather than attempted */
+    compare(noise_handshakestate_new_by_name
+                (&state, single, NOISE_ROLE_RESPONDER),
+            NOISE_ERROR_NONE);
+    compare(noise_handshakestate_fallback(state),
+            NOISE_ERROR_NOT_APPLICABLE);
+    compare(noise_handshakestate_fallback_to(state, "XXfallback"),
+            NOISE_ERROR_NOT_APPLICABLE);
+    compare(noise_handshakestate_fallback_to(0, "XXfallback"),
+            NOISE_ERROR_INVALID_PARAM);
+    compare(noise_handshakestate_fallback_to(state, 0),
+            NOISE_ERROR_INVALID_PARAM);
+    compare(noise_handshakestate_free(state), NOISE_ERROR_NONE);
+#endif
+
+#if !NOISE_USE_HFS
+    /* A pattern that asks for hybrid forward secrecy is unknown */
+    {
+        static const char hfs[] = "Noise_NNhfs_25519+NewHope_ChaChaPoly_SHA256";
+        compare(noise_protocol_name_to_id(&id, hfs, strlen(hfs)),
+                NOISE_ERROR_UNKNOWN_NAME);
+    }
+#endif
+
+    (void)state;
+    (void)id;
+    (void)single;
+}


### PR DESCRIPTION
Microcontroller builds pay for parts of the library that ESPHome never reaches. The algorithm name tables exist so a caller can name a protocol as a string; ESPHome builds its handshake from ids. The "fallback" and "hfs" pattern modifiers are never asked for either.

Three switches let a build leave them out. All three default to on, so a build that says nothing gets the library it always had, and the host test suite keeps exercising the full code.

`NOISE_USE_PROTOCOL_NAME_TABLE` keeps the name tables and the parser and formatter that walk them. Off, `noise_protocol_name_to_id` and `noise_protocol_id_to_name` know only the one protocol ESPHome speaks and answer `NOISE_ERROR_UNKNOWN_ID` or `NOISE_ERROR_UNKNOWN_NAME` for anything else. No declared function disappears; the rest of the name API stays, and the linker drops the tables along with whatever no longer reaches them. A new host test builds both versions of the two functions into one binary and checks they agree, since the name they return is hashed into the handshake.

`NOISE_USE_FALLBACK` and `NOISE_USE_HFS` keep those two pattern modifiers. Off, asking for one returns `NOISE_ERROR_UNKNOWN_NAME` and the two fallback entry points return `NOISE_ERROR_NOT_APPLICABLE`.

The guard depends on `NOISE_USE_CURVE25519`, `NOISE_USE_CURVE448` and `NOISE_USE_NEWHOPE` being honoured; the misspelt `NOISE_USE_CRUVE25519` guard and the default-to-0 blocks for the other two landed on main with #38, so this diff builds on them rather than carrying them.

## Measurements

ESPHome device with API encryption and OTA, built against this branch with the three switches set to 0, against the same device built on `main`.

| board | flash before | flash after | RAM before | RAM after |
|---|---|---|---|---|
| d1 mini, ESP8266, Arduino | 389791 | 388619 | 30188 | 29784 |
| M5Stack AtomU, ESP32, ESP-IDF 5.5.5 | 741811 | 740595 | 44512 | 44512 |

The ESP8266 RAM saving is the name table itself, which lives in DRAM on that chip; the one name the reduced version keeps is kept in flash there rather than joining it. On the ESP32 the tables are in flash, so RAM does not move.

Built without the switches, both boards come out at exactly the numbers in the before column, so nothing moves for a build that does not ask.

## Testing

The AtomU ran 20 encrypted API connects against the built image, median 133 ms, matching the same 20 connects before the change; a wrong key is still rejected. The loopback handshake bench on the same board is unchanged. Both boards above compile and run, and ESP-IDF 6.0.2 compiles as well.

