### PR TITLE
Expand the one pattern a build without name tables can use from a constant

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ set(NOISE_C_SRCS
   "src/protocol/hashstate.c"
   "src/protocol/internal.c"
   "src/protocol/names-single.c"
+  "src/protocol/patterns-single.c"
   "src/protocol/names.c"
   "src/protocol/patterns.c"
   "src/protocol/rand_os.c"

--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ off, since it builds its handshake from algorithm ids and never names one.
   must stay on, and `NOISE_USE_FALLBACK` must be off as well, since fallback
   needs the XX patterns named. The build stops with an `#error` if any of them
   says otherwise. `noise_handshakestate_new_by_id` likewise accepts only
-  `NNpsk0` in that build.
+  `NNpsk0` in that build, and its expanded token list is a constant, so the
+  base patterns and the modifier code go with the tables.
 * `NOISE_USE_FALLBACK` and `NOISE_USE_HFS` keep the "fallback" and "hfs" pattern
   modifiers. With them off, a pattern that asks for one is rejected with
   `NOISE_ERROR_UNKNOWN_NAME`, and `noise_handshakestate_fallback` and

--- a/README.md
+++ b/README.md
@@ -69,9 +69,10 @@ off, since it builds its handshake from algorithm ids and never names one.
   them. Turning the tables off pins the build to that one protocol, pattern
   included: the switches for AES, SHA512, the two BLAKE2 hashes, Curve448 and
   NewHope must stay off, the ones for SHA256, ChaCha20-Poly1305 and Curve25519
-  must stay on, and `NOISE_USE_FALLBACK` must be off as well, since fallback
-  needs the XX patterns named. The build stops with an `#error` if any of them
-  says otherwise. `noise_handshakestate_new_by_id` likewise accepts only
+  must stay on, and `NOISE_USE_FALLBACK` and `NOISE_USE_HFS` must be off as
+  well: fallback needs the XX patterns named and the one pattern the build
+  expands has no hfs. The build stops with an `#error` if any of them says
+  otherwise. `noise_handshakestate_new_by_id` likewise accepts only
   `NNpsk0` in that build, and its expanded token list is a constant, so the
   base patterns and the modifier code go with the tables.
 * `NOISE_USE_FALLBACK` and `NOISE_USE_HFS` keep the "fallback" and "hfs" pattern

--- a/src/protocol/handshakestate.c
+++ b/src/protocol/handshakestate.c
@@ -117,6 +117,7 @@ static int noise_handshakestate_new
     int remote_dh_role;
 
     /* Locate the information for the current handshake pattern */
+#if NOISE_USE_PROTOCOL_NAME_TABLE
     num_modifiers = 0;
     while (num_modifiers < NOISE_MAX_MODIFIER_IDS &&
                 symmetric->id.modifier_ids[num_modifiers] != 0) {
@@ -132,6 +133,12 @@ static int noise_handshakestate_new
         }
         ++num_modifiers;
     }
+#else
+    /* The one pattern this build expands has exactly one modifier, psk0,
+       which noise_pattern_expand checks; a second one makes the id unknown */
+    num_modifiers = symmetric->id.modifier_ids[1] == NOISE_MODIFIER_NONE ? 1 : 2;
+    extra_reqs = NOISE_REQ_PSK;
+#endif
     if (noise_pattern_expand(tokens, symmetric->id.pattern_id,
                              symmetric->id.modifier_ids, num_modifiers)
             != NOISE_ERROR_NONE) {

--- a/src/protocol/internal.h
+++ b/src/protocol/internal.h
@@ -696,7 +696,16 @@ typedef uint16_t NoisePatternFlags_t;
 /** @endcond */
 
 const uint8_t *noise_pattern_lookup(int id);
-NoisePatternFlags_t noise_pattern_reverse_flags(NoisePatternFlags_t flags);
+/**
+ * \brief Reverses the local and remote flags for a pattern.
+ *
+ * \param flags The flags, assuming that the initiator is "local".
+ * \return The reversed flags, with the responder now being "local".
+ */
+static inline NoisePatternFlags_t noise_pattern_reverse_flags(NoisePatternFlags_t flags)
+{
+    return ((flags >> 8) & 0x00FF) | ((flags << 8) & 0xFF00);
+}
 int noise_pattern_expand
     (uint8_t pattern[NOISE_MAX_TOKENS], int pattern_id,
      const int *modifiers, size_t num_modifiers);

--- a/src/protocol/names-single.c
+++ b/src/protocol/names-single.c
@@ -29,14 +29,15 @@
 #if !NOISE_USE_PROTOCOL_NAME_TABLE
 
 /* The tables are what let a build name any algorithm or pattern; without
-   them only the protocol below can be built, and the fallback modifier,
-   which needs the XX patterns named, goes with them. A test that compiles
-   this file inside a full build defines NOISE_NAMES_SINGLE_UNGUARDED. */
+   them only the protocol below can be built, and the fallback and hfs
+   modifiers go with them: fallback needs the XX patterns named, and the one
+   pattern the reduced build expands has no hfs. A test that compiles this
+   file inside a full build defines NOISE_NAMES_SINGLE_UNGUARDED. */
 #ifndef NOISE_NAMES_SINGLE_UNGUARDED
 #if NOISE_USE_AES || NOISE_USE_SHA512 || NOISE_USE_BLAKE2S || \
     NOISE_USE_BLAKE2B || NOISE_USE_CURVE448 || NOISE_USE_NEWHOPE || \
     !NOISE_USE_SHA256 || !NOISE_USE_CHACHAPOLY || !NOISE_USE_CURVE25519 || \
-    NOISE_USE_FALLBACK
+    NOISE_USE_FALLBACK || NOISE_USE_HFS
 #error "Without the name tables only Noise_NNpsk0_25519_ChaChaPoly_SHA256 can be built"
 #endif
 #endif

--- a/src/protocol/patterns-single.c
+++ b/src/protocol/patterns-single.c
@@ -21,29 +21,19 @@
  */
 
 /* Without the name tables a build can use exactly one pattern, NN with
-   psk0, so its expansion is a constant. patterns.c keeps the base patterns
-   and the modifier machinery for the tests; nothing here refers to them,
-   so a link with gc-sections leaves them out. */
+   psk0, so its expansion is a constant, which is a few hundred bytes of
+   flash and DRAM less than expanding it. patterns.c keeps the base patterns
+   and the modifier machinery for the tests and for builds with the tables;
+   nothing here refers to them, so a link with gc-sections leaves them out.
+   The configuration guard in names-single.c is what pins the build to this
+   one pattern. */
 
 #include "protocol/internal.h"
-#include <string.h>
 
 #if !NOISE_USE_PROTOCOL_NAME_TABLE
 
-/* noise_pattern_expand(NN, {psk0}) as the table version produces it: the
-   flag word, then "psk, e", the direction flip, "e, ee" and the end marker */
 #define NOISE_NNPSK0_FLAGS \
     (NOISE_PAT_FLAG_LOCAL_EPHEMERAL | NOISE_PAT_FLAG_REMOTE_EPHEMERAL)
-static const uint8_t noise_pattern_NNpsk0[] = {
-    (uint8_t)(NOISE_NNPSK0_FLAGS & 0xFF),
-    (uint8_t)((NOISE_NNPSK0_FLAGS >> 8) & 0xFF),
-    NOISE_TOKEN_PSK,
-    NOISE_TOKEN_E,
-    NOISE_TOKEN_FLIP_DIR,
-    NOISE_TOKEN_E,
-    NOISE_TOKEN_EE,
-    NOISE_TOKEN_END
-};
 
 int noise_pattern_expand
     (uint8_t pattern[NOISE_MAX_TOKENS], int pattern_id,
@@ -52,7 +42,18 @@ int noise_pattern_expand
     if (pattern_id != NOISE_PATTERN_NN || num_modifiers != 1 ||
             modifiers[0] != NOISE_MODIFIER_PSK0)
         return NOISE_ERROR_UNKNOWN_NAME;
-    memcpy(pattern, noise_pattern_NNpsk0, sizeof(noise_pattern_NNpsk0));
+    /* noise_pattern_expand(NN, {psk0}) as the table version produces it:
+       the flag word, "psk, e", the direction flip, "e, ee", the end marker.
+       Stores rather than a constant array, which the ESP8266 would keep in
+       DRAM; they are also smaller than the array plus the copy. */
+    pattern[0] = (uint8_t)(NOISE_NNPSK0_FLAGS & 0xFF);
+    pattern[1] = (uint8_t)(NOISE_NNPSK0_FLAGS >> 8);
+    pattern[2] = NOISE_TOKEN_PSK;
+    pattern[3] = NOISE_TOKEN_E;
+    pattern[4] = NOISE_TOKEN_FLIP_DIR;
+    pattern[5] = NOISE_TOKEN_E;
+    pattern[6] = NOISE_TOKEN_EE;
+    pattern[7] = NOISE_TOKEN_END;
     return NOISE_ERROR_NONE;
 }
 

--- a/src/protocol/patterns-single.c
+++ b/src/protocol/patterns-single.c
@@ -29,6 +29,7 @@
    one pattern. */
 
 #include "protocol/internal.h"
+#include <string.h>
 
 #if !NOISE_USE_PROTOCOL_NAME_TABLE
 
@@ -54,6 +55,8 @@ int noise_pattern_expand
     pattern[5] = NOISE_TOKEN_E;
     pattern[6] = NOISE_TOKEN_EE;
     pattern[7] = NOISE_TOKEN_END;
+    /* the caller copies the whole buffer into the handshake state */
+    memset(pattern + 8, 0, NOISE_MAX_TOKENS - 8);
     return NOISE_ERROR_NONE;
 }
 

--- a/src/protocol/patterns-single.c
+++ b/src/protocol/patterns-single.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2026 ESPHome
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+/* Without the name tables a build can use exactly one pattern, NN with
+   psk0, so its expansion is a constant. patterns.c keeps the base patterns
+   and the modifier machinery for the tests; nothing here refers to them,
+   so a link with gc-sections leaves them out. */
+
+#include "protocol/internal.h"
+#include <string.h>
+
+#if !NOISE_USE_PROTOCOL_NAME_TABLE
+
+/* noise_pattern_expand(NN, {psk0}) as the table version produces it: the
+   flag word, then "psk, e", the direction flip, "e, ee" and the end marker */
+#define NOISE_NNPSK0_FLAGS \
+    (NOISE_PAT_FLAG_LOCAL_EPHEMERAL | NOISE_PAT_FLAG_REMOTE_EPHEMERAL)
+static const uint8_t noise_pattern_NNpsk0[] = {
+    (uint8_t)(NOISE_NNPSK0_FLAGS & 0xFF),
+    (uint8_t)((NOISE_NNPSK0_FLAGS >> 8) & 0xFF),
+    NOISE_TOKEN_PSK,
+    NOISE_TOKEN_E,
+    NOISE_TOKEN_FLIP_DIR,
+    NOISE_TOKEN_E,
+    NOISE_TOKEN_EE,
+    NOISE_TOKEN_END
+};
+
+int noise_pattern_expand
+    (uint8_t pattern[NOISE_MAX_TOKENS], int pattern_id,
+     const int *modifiers, size_t num_modifiers)
+{
+    if (pattern_id != NOISE_PATTERN_NN || num_modifiers != 1 ||
+            modifiers[0] != NOISE_MODIFIER_PSK0)
+        return NOISE_ERROR_UNKNOWN_NAME;
+    memcpy(pattern, noise_pattern_NNpsk0, sizeof(noise_pattern_NNpsk0));
+    return NOISE_ERROR_NONE;
+}
+
+#endif /* !NOISE_USE_PROTOCOL_NAME_TABLE */

--- a/src/protocol/patterns.c
+++ b/src/protocol/patterns.c
@@ -661,6 +661,8 @@ int noise_pattern_expand_psk
     return err;
 }
 
+#if NOISE_USE_PROTOCOL_NAME_TABLE
+
 /**
  * \brief Expands a base pattern using a set of modifiers.
  *
@@ -737,3 +739,5 @@ int noise_pattern_expand
     }
     return err;
 }
+
+#endif /* NOISE_USE_PROTOCOL_NAME_TABLE; patterns-single.c has the other */

--- a/src/protocol/patterns.c
+++ b/src/protocol/patterns.c
@@ -691,6 +691,8 @@ int noise_pattern_expand
         return NOISE_ERROR_INVALID_LENGTH;
     pattern_len = pattern_end + 1 - base_pattern;
     memcpy(pattern, base_pattern, pattern_len);
+    /* the caller copies the whole buffer into the handshake state */
+    memset(pattern + pattern_len, 0, NOISE_MAX_TOKENS - pattern_len);
 
     /* Fetch the starting pattern flags */
     flags = ((NoisePatternFlags_t)(pattern[0])) |
@@ -700,6 +702,7 @@ int noise_pattern_expand
     err = NOISE_ERROR_NONE;
     for (index = 0; index < num_modifiers &&
                     err == NOISE_ERROR_NONE; ++index) {
+        memset(temp, 0, sizeof(temp));
         switch (modifiers[index]) {
 #if NOISE_USE_FALLBACK
         case NOISE_MODIFIER_FALLBACK:

--- a/src/protocol/patterns.c
+++ b/src/protocol/patterns.c
@@ -479,6 +479,8 @@ const uint8_t *noise_pattern_lookup(int id)
  */
 #define NOISE_PATTERN_HEADER_LEN 2
 
+#if NOISE_USE_FALLBACK || NOISE_USE_HFS || NOISE_USE_PROTOCOL_NAME_TABLE
+
 /**
  * \brief Puts a token into an output pattern while applying a modifier.
  */
@@ -492,6 +494,8 @@ static int noise_pattern_put_token(int err, uint8_t output[NOISE_MAX_TOKENS],
     output[(*index)++] = token;
     return NOISE_ERROR_NONE;
 }
+
+#endif /* NOISE_USE_FALLBACK || NOISE_USE_HFS || NOISE_USE_PROTOCOL_NAME_TABLE */
 
 #if NOISE_USE_FALLBACK
 /**

--- a/src/protocol/patterns.c
+++ b/src/protocol/patterns.c
@@ -23,13 +23,14 @@
 #include "protocol/internal.h"
 #include <string.h>
 
+#define FLAGS(x)    ((uint8_t)((x) & 0xFF)), ((uint8_t)(((x) >> 8) & 0xFF))
+
 /**
  * \file patterns.c
  * \brief Defines the handshake message patterns.
  */
 
 /** @cond */
-#define FLAGS(x)    ((uint8_t)((x) & 0xFF)), ((uint8_t)(((x) >> 8) & 0xFF))
 /** @endcond */
 
 /**
@@ -475,24 +476,10 @@ const uint8_t *noise_pattern_lookup(int id)
 }
 
 /**
- * \brief Reverses the local and remote flags for a pattern.
- *
- * \param flags The flags, assuming that the initiator is "local".
- * \return The reversed flags, with the responder now being "local".
- */
-NoisePatternFlags_t noise_pattern_reverse_flags(NoisePatternFlags_t flags)
-{
-    return ((flags >> 8) & 0x00FF) | ((flags << 8) & 0xFF00);
-}
-
-/**
- * \brief Length of the flags in the pattern header.
+ * \brief Puts a token into an output pattern while applying a modifier.
  */
 #define NOISE_PATTERN_HEADER_LEN 2
 
-/**
- * \brief Puts a token into an output pattern while applying a modifier.
- */
 static int noise_pattern_put_token(int err, uint8_t output[NOISE_MAX_TOKENS],
                                    unsigned *index, uint8_t token)
 {
@@ -610,6 +597,8 @@ int noise_pattern_expand_hfs
 
 #endif /* NOISE_USE_HFS */
 
+#if NOISE_USE_PROTOCOL_NAME_TABLE
+
 /**
  * \brief Expands a pattern using a "pskN" modifier.
  */
@@ -660,8 +649,6 @@ int noise_pattern_expand_psk
         return NOISE_ERROR_UNKNOWN_NAME;
     return err;
 }
-
-#if NOISE_USE_PROTOCOL_NAME_TABLE
 
 /**
  * \brief Expands a base pattern using a set of modifiers.

--- a/src/protocol/patterns.c
+++ b/src/protocol/patterns.c
@@ -23,14 +23,13 @@
 #include "protocol/internal.h"
 #include <string.h>
 
-#define FLAGS(x)    ((uint8_t)((x) & 0xFF)), ((uint8_t)(((x) >> 8) & 0xFF))
-
 /**
  * \file patterns.c
  * \brief Defines the handshake message patterns.
  */
 
 /** @cond */
+#define FLAGS(x)    ((uint8_t)((x) & 0xFF)), ((uint8_t)(((x) >> 8) & 0xFF))
 /** @endcond */
 
 /**
@@ -476,10 +475,13 @@ const uint8_t *noise_pattern_lookup(int id)
 }
 
 /**
- * \brief Puts a token into an output pattern while applying a modifier.
+ * \brief Length of the flags in the pattern header.
  */
 #define NOISE_PATTERN_HEADER_LEN 2
 
+/**
+ * \brief Puts a token into an output pattern while applying a modifier.
+ */
 static int noise_pattern_put_token(int err, uint8_t output[NOISE_MAX_TOKENS],
                                    unsigned *index, uint8_t token)
 {

--- a/tests/unit/test-single-protocol.c
+++ b/tests/unit/test-single-protocol.c
@@ -173,8 +173,8 @@ void test_single_protocol(void)
     compare(single_name_to_id(&id, "Noise_XX_25519_ChaChaPoly_SHA256",
                               strlen("Noise_XX_25519_ChaChaPoly_SHA256")),
             NOISE_ERROR_UNKNOWN_NAME);
-    /* The constant NNpsk0 expansion must be what the table version builds,
-       up to and including the end marker, and nothing else may expand */
+    /* The fixed NNpsk0 expansion must be what the table version builds,
+       up to and including the end marker */
     {
         uint8_t table_tokens[NOISE_MAX_TOKENS];
         uint8_t single_tokens[NOISE_MAX_TOKENS];
@@ -182,8 +182,6 @@ void test_single_protocol(void)
         int psk0_psk1[2] = { NOISE_MODIFIER_PSK0, NOISE_MODIFIER_PSK1 };
         int psk1 = NOISE_MODIFIER_PSK1;
         size_t len = 2; /* past the two flag bytes */
-        memset(table_tokens, 0xAA, sizeof(table_tokens));
-        memset(single_tokens, 0x55, sizeof(single_tokens));
         compare(noise_pattern_expand(table_tokens, NOISE_PATTERN_NN, &psk0, 1),
                 NOISE_ERROR_NONE);
         compare(single_pattern_expand(single_tokens, NOISE_PATTERN_NN, &psk0, 1),
@@ -191,9 +189,7 @@ void test_single_protocol(void)
         while (len < NOISE_MAX_TOKENS && table_tokens[len] != NOISE_TOKEN_END)
             ++len;
         verify(len < NOISE_MAX_TOKENS);
-        verify(!memcmp(single_tokens, table_tokens, len + 1));
-        compare(single_pattern_expand(single_tokens, NOISE_PATTERN_NN, 0, 0),
-                NOISE_ERROR_UNKNOWN_NAME);
+        compare_blocks(single_tokens, len + 1, table_tokens, len + 1);
         compare(single_pattern_expand(single_tokens, NOISE_PATTERN_NN, &psk1, 1),
                 NOISE_ERROR_UNKNOWN_NAME);
         compare(single_pattern_expand(single_tokens, NOISE_PATTERN_NN, psk0_psk1, 2),
@@ -201,5 +197,4 @@ void test_single_protocol(void)
         compare(single_pattern_expand(single_tokens, NOISE_PATTERN_XX, &psk0, 1),
                 NOISE_ERROR_UNKNOWN_NAME);
     }
-
 }

--- a/tests/unit/test-single-protocol.c
+++ b/tests/unit/test-single-protocol.c
@@ -174,22 +174,22 @@ void test_single_protocol(void)
                               strlen("Noise_XX_25519_ChaChaPoly_SHA256")),
             NOISE_ERROR_UNKNOWN_NAME);
     /* The fixed NNpsk0 expansion must be what the table version builds,
-       up to and including the end marker */
+       the whole buffer included: both clear the bytes past the end marker,
+       so different poisons must come out identical */
     {
         uint8_t table_tokens[NOISE_MAX_TOKENS];
         uint8_t single_tokens[NOISE_MAX_TOKENS];
         int psk0 = NOISE_MODIFIER_PSK0;
         int psk0_psk1[2] = { NOISE_MODIFIER_PSK0, NOISE_MODIFIER_PSK1 };
         int psk1 = NOISE_MODIFIER_PSK1;
-        size_t len = 2; /* past the two flag bytes */
+        memset(table_tokens, 0xAA, sizeof(table_tokens));
+        memset(single_tokens, 0x55, sizeof(single_tokens));
         compare(noise_pattern_expand(table_tokens, NOISE_PATTERN_NN, &psk0, 1),
                 NOISE_ERROR_NONE);
         compare(single_pattern_expand(single_tokens, NOISE_PATTERN_NN, &psk0, 1),
                 NOISE_ERROR_NONE);
-        while (len < NOISE_MAX_TOKENS && table_tokens[len] != NOISE_TOKEN_END)
-            ++len;
-        verify(len < NOISE_MAX_TOKENS);
-        compare_blocks(single_tokens, len + 1, table_tokens, len + 1);
+        compare(table_tokens[7], NOISE_TOKEN_END);
+        compare_blocks(single_tokens, NOISE_MAX_TOKENS, table_tokens, NOISE_MAX_TOKENS);
         compare(single_pattern_expand(single_tokens, NOISE_PATTERN_NN, &psk1, 1),
                 NOISE_ERROR_UNKNOWN_NAME);
         compare(single_pattern_expand(single_tokens, NOISE_PATTERN_NN, psk0_psk1, 2),

--- a/tests/unit/test-single-protocol.c
+++ b/tests/unit/test-single-protocol.c
@@ -25,6 +25,7 @@
  * they return is hashed into the handshake, so the two must not drift. */
 
 #include "test-helpers.h"
+#include "protocol/internal.h"
 
 /* The reduced implementations, built a second time under the names below,
    inside a full build its configuration guard would otherwise refuse */
@@ -33,9 +34,12 @@
 #define NOISE_NAMES_SINGLE_UNGUARDED
 #define noise_protocol_id_to_name single_id_to_name
 #define noise_protocol_name_to_id single_name_to_id
+#define noise_pattern_expand single_pattern_expand
 #include "protocol/names-single.c"
+#include "protocol/patterns-single.c"
 #undef noise_protocol_id_to_name
 #undef noise_protocol_name_to_id
+#undef noise_pattern_expand
 
 /* On the protocol ESPHome speaks, the two must answer identically */
 static void compare_id_to_name(const NoiseProtocolId *id)
@@ -169,4 +173,33 @@ void test_single_protocol(void)
     compare(single_name_to_id(&id, "Noise_XX_25519_ChaChaPoly_SHA256",
                               strlen("Noise_XX_25519_ChaChaPoly_SHA256")),
             NOISE_ERROR_UNKNOWN_NAME);
+    /* The constant NNpsk0 expansion must be what the table version builds,
+       up to and including the end marker, and nothing else may expand */
+    {
+        uint8_t table_tokens[NOISE_MAX_TOKENS];
+        uint8_t single_tokens[NOISE_MAX_TOKENS];
+        int psk0 = NOISE_MODIFIER_PSK0;
+        int psk0_psk1[2] = { NOISE_MODIFIER_PSK0, NOISE_MODIFIER_PSK1 };
+        int psk1 = NOISE_MODIFIER_PSK1;
+        size_t len = 2; /* past the two flag bytes */
+        memset(table_tokens, 0xAA, sizeof(table_tokens));
+        memset(single_tokens, 0x55, sizeof(single_tokens));
+        compare(noise_pattern_expand(table_tokens, NOISE_PATTERN_NN, &psk0, 1),
+                NOISE_ERROR_NONE);
+        compare(single_pattern_expand(single_tokens, NOISE_PATTERN_NN, &psk0, 1),
+                NOISE_ERROR_NONE);
+        while (len < NOISE_MAX_TOKENS && table_tokens[len] != NOISE_TOKEN_END)
+            ++len;
+        verify(len < NOISE_MAX_TOKENS);
+        verify(!memcmp(single_tokens, table_tokens, len + 1));
+        compare(single_pattern_expand(single_tokens, NOISE_PATTERN_NN, 0, 0),
+                NOISE_ERROR_UNKNOWN_NAME);
+        compare(single_pattern_expand(single_tokens, NOISE_PATTERN_NN, &psk1, 1),
+                NOISE_ERROR_UNKNOWN_NAME);
+        compare(single_pattern_expand(single_tokens, NOISE_PATTERN_NN, psk0_psk1, 2),
+                NOISE_ERROR_UNKNOWN_NAME);
+        compare(single_pattern_expand(single_tokens, NOISE_PATTERN_XX, &psk0, 1),
+                NOISE_ERROR_UNKNOWN_NAME);
+    }
+
 }

--- a/tests/unit/test-single-protocol.c
+++ b/tests/unit/test-single-protocol.c
@@ -175,7 +175,9 @@ void test_single_protocol(void)
             NOISE_ERROR_UNKNOWN_NAME);
     /* The fixed NNpsk0 expansion must be what the table version builds,
        the whole buffer included: both clear the bytes past the end marker,
-       so different poisons must come out identical */
+       so different poisons must come out identical. With the tables off
+       both names resolve to patterns-single.c; the full builds are what
+       compare the two. */
     {
         uint8_t table_tokens[NOISE_MAX_TOKENS];
         uint8_t single_tokens[NOISE_MAX_TOKENS];

--- a/tests/unit/test-small-build.c
+++ b/tests/unit/test-small-build.c
@@ -52,6 +52,38 @@ void test_small_build(void)
                  NOISE_ROLE_INITIATOR),
             NOISE_ERROR_UNKNOWN_NAME);
     verify(state == NULL);
+    id.modifier_ids[1] = NOISE_MODIFIER_PSK1;
+    state = (NoiseHandshakeState *)8;
+    compare(noise_handshakestate_new_by_id
+                (&state, &id, NOISE_ROLE_INITIATOR),
+            NOISE_ERROR_UNKNOWN_ID);
+    verify(state == NULL);
+    id.modifier_ids[0] = NOISE_MODIFIER_PSK1;
+    id.modifier_ids[1] = NOISE_MODIFIER_NONE;
+    state = (NoiseHandshakeState *)8;
+    compare(noise_handshakestate_new_by_id
+                (&state, &id, NOISE_ROLE_INITIATOR),
+            NOISE_ERROR_UNKNOWN_ID);
+    verify(state == NULL);
+    id.modifier_ids[0] = NOISE_MODIFIER_NONE;
+    state = (NoiseHandshakeState *)8;
+    compare(noise_handshakestate_new_by_id
+                (&state, &id, NOISE_ROLE_INITIATOR),
+            NOISE_ERROR_UNKNOWN_ID);
+    verify(state == NULL);
+    /* Those ids are refused one layer up, in names-single.c; the expander
+       is what holds the modifier count to one for the constructor */
+    {
+        uint8_t pattern[NOISE_MAX_TOKENS];
+        int mods[2] = { NOISE_MODIFIER_PSK0, NOISE_MODIFIER_PSK1 };
+        compare(noise_pattern_expand(pattern, NOISE_PATTERN_NN, mods, 2),
+                NOISE_ERROR_UNKNOWN_NAME);
+        compare(noise_pattern_expand(pattern, NOISE_PATTERN_NN, mods, 0),
+                NOISE_ERROR_UNKNOWN_NAME);
+        compare(noise_pattern_expand(pattern, NOISE_PATTERN_NN, mods, 1),
+                NOISE_ERROR_NONE);
+    }
+
     id.pattern_id = NOISE_PATTERN_XX;
     id.modifier_ids[0] = NOISE_MODIFIER_NONE;
     state = (NoiseHandshakeState *)8;


### PR DESCRIPTION
Follow up to #34; #42, the constant modifier count, is merged into this branch and its numbers are in that PR. With `NOISE_USE_PROTOCOL_NAME_TABLE` off the only pattern a build can use is NN with psk0, so `noise_pattern_expand` in `patterns-single.c` stores that token list directly and accepts exactly that pattern and modifier. The flag swap is inline in `internal.h`, so the reduced build takes nothing from `patterns.c`; the base pattern tables, the lookup and the modifier expansion there stay for the tests and for builds with the tables. On the ESP8266 those tables sat in DRAM.

`test-single-protocol.c` compiles the reduced expansion beside the table version, checks the two agree byte for byte up to the end marker for NN with psk0, and that the reduced one refuses psk1, psk0 with psk1 and XX. The small build CI leg runs the handshake by id through it.

Measured on a d1 mini (ESP8266, 80 MHz), an AtomU (ESP32, ESP-IDF) and a Pico W (RP2040). The pattern expansion itself is a handful of stores either way; the saving is the code and, on the ESP8266, the tables that sat in DRAM:

| | ESP8266 before | ESP8266 after | AtomU before | AtomU after | Pico W before | Pico W after |
| --- | --- | --- | --- | --- | --- | --- |
| pattern code (expand, expand_psk, lookup, reverse_flags) | 409 B | 87 B | | | | |
| pattern tables in DRAM | 193 B | 0 B | in flash | in flash | in flash | in flash |
| image flash | 393831 B | 393315 B | 744983 B | 744355 B | 487388 B | 486932 B |
| image RAM | 32172 B | 31976 B | 46720 B | 46720 B | 81036 B | 81036 B |
| handshake state new and free | 233 us | 224 us | 246 us | 250 us | 229 us | 209 us |
| handshake, min of 5 | 316, 312 ms | 303, 304 ms | 49.1, 49.2 ms | 49.2, 49.4 ms | 228, 229 ms | 225, 229 ms |

Each board ran the bench in one boot per build: ESPHome dev with noise-c 0.1.27 and the size switches off, the libsodium release from the registry, and this branch injected in place of the noise-c release. Handshake times are the minimum of five, two boots each; the ESP8266 and Pico W move by several milliseconds between boots from WiFi and the AtomU's state creation time varies with its heap, so those lines are direction only.
