### PR TITLE
Turn the size switches off in library.json

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,9 @@ if(ESP_PLATFORM)
     INCLUDE_DIRS "include" "src"
     REQUIRES esphome__libsodium
   )
+  # The same three switches library.json turns off for PlatformIO builds
+  target_compile_definitions(${COMPONENT_LIB} PRIVATE
+    NOISE_USE_PROTOCOL_NAME_TABLE=0 NOISE_USE_FALLBACK=0 NOISE_USE_HFS=0)
 else()
   cmake_minimum_required(VERSION 3.13)
   if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)

--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ Three macros in `include/noise/defines.h` trade features for flash and RAM.
 All three are on by default, so a build that says nothing gets the library it
 always had; define one as 0 to leave that feature out. The packaged builds turn
 all three off without asking: `library.json` for the PlatformIO library, and
-the ESP-IDF component's `CMakeLists.txt` for the Espressif registry. A CMake
-build of the sources keeps the defaults, so the tests cover the whole library.
+`CMakeLists.txt` for any ESP-IDF component build, from the Espressif registry
+or a local copy. A CMake build of the sources on a host keeps the defaults, so
+the tests cover the whole library.
 ESPHome builds its handshake from algorithm ids and never names one.
 
 * `NOISE_USE_PROTOCOL_NAME_TABLE` keeps the tables that turn algorithm names

--- a/README.md
+++ b/README.md
@@ -56,10 +56,11 @@ Size switches for microcontroller builds
 
 Three macros in `include/noise/defines.h` trade features for flash and RAM.
 All three are on by default, so a build that says nothing gets the library it
-always had; define one as 0 to leave that feature out. `library.json` turns all
-three off, so a build that takes the library from the PlatformIO or Espressif
-registry gets the small library without asking; ESPHome builds its handshake
-from algorithm ids and never names one.
+always had; define one as 0 to leave that feature out. The packaged builds turn
+all three off without asking: `library.json` for the PlatformIO library, and
+the ESP-IDF component's `CMakeLists.txt` for the Espressif registry. A CMake
+build of the sources keeps the defaults, so the tests cover the whole library.
+ESPHome builds its handshake from algorithm ids and never names one.
 
 * `NOISE_USE_PROTOCOL_NAME_TABLE` keeps the tables that turn algorithm names
   into ids and back. With it off, `noise_protocol_name_to_id` and

--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ Size switches for microcontroller builds
 Three macros in `include/noise/defines.h` trade features for flash and RAM.
 All three are on by default, so a build that says nothing gets the library it
 always had; define one as 0 to leave that feature out. The packaged builds turn
-all three off without asking: `library.json` for the PlatformIO library, and
+all three off without asking, since ESPHome builds its handshake from algorithm
+ids and never names one: `library.json` for the PlatformIO library, and
 `CMakeLists.txt` for any ESP-IDF component build, from the Espressif registry
 or a local copy. A CMake build of the sources on a host keeps the defaults, so
 the tests cover the whole library.
-ESPHome builds its handshake from algorithm ids and never names one.
 
 * `NOISE_USE_PROTOCOL_NAME_TABLE` keeps the tables that turn algorithm names
   into ids and back. With it off, `noise_protocol_name_to_id` and

--- a/README.md
+++ b/README.md
@@ -56,8 +56,10 @@ Size switches for microcontroller builds
 
 Three macros in `include/noise/defines.h` trade features for flash and RAM.
 All three are on by default, so a build that says nothing gets the library it
-always had; define one as 0 to leave that feature out. ESPHome turns all three
-off, since it builds its handshake from algorithm ids and never names one.
+always had; define one as 0 to leave that feature out. `library.json` turns all
+three off, so a build that takes the library from the PlatformIO or Espressif
+registry gets the small library without asking; ESPHome builds its handshake
+from algorithm ids and never names one.
 
 * `NOISE_USE_PROTOCOL_NAME_TABLE` keeps the tables that turn algorithm names
   into ids and back. With it off, `noise_protocol_name_to_id` and

--- a/include/noise/defines.h
+++ b/include/noise/defines.h
@@ -69,7 +69,8 @@
 #endif
 
 /* Three switches for builds that want the library smaller, all on by default
-   so nothing changes unless the build asks. ESPHome turns them off. */
+   so nothing changes unless the build asks. library.json turns them off, so
+   every build that takes the library from a registry gets the small one. */
 
 /* Format protocol names from the id tables. Off, noise_protocol_id_to_name
    knows the one protocol ESPHome speaks and the tables are left out, which

--- a/include/noise/defines.h
+++ b/include/noise/defines.h
@@ -69,8 +69,8 @@
 #endif
 
 /* Three switches for builds that want the library smaller, all on by default
-   so nothing changes unless the build asks. library.json turns them off, so
-   every build that takes the library from a registry gets the small one. */
+   so a build of the sources gets the library it always had; the README says
+   which builds turn them off. */
 
 /* Format protocol names from the id tables. Off, noise_protocol_id_to_name
    knows the one protocol ESPHome speaks and the tables are left out, which

--- a/library.json
+++ b/library.json
@@ -14,7 +14,12 @@
     ],
     "build": {
         "includeDir": "include",
-        "srcDir": "src"
+        "srcDir": "src",
+        "flags": [
+            "-DNOISE_USE_PROTOCOL_NAME_TABLE=0",
+            "-DNOISE_USE_FALLBACK=0",
+            "-DNOISE_USE_HFS=0"
+        ]
     },
     "dependencies": [
         {


### PR DESCRIPTION
ESPHome turns the three size switches off with project build flags (esphome/esphome#19062). Those reach the library on PlatformIO and ESP-IDF, but the Zephyr backend compiles a library with the flags from its own `library.json` only, so an nRF52 image keeps the name tables. Set here they travel with the library on every backend, and the project side can drop its copies after the next release. No public header reads the three macros, so the application and the library cannot disagree.

The CMake build and the tests are unchanged; they still see the defaults from `defines.h`.

On the three boards ESPHome already passes the three defines as project flags, so the image is byte for byte the same with this branch: 393831 bytes of flash on a d1 mini, 744983 on an AtomU over ESP-IDF, 487388 on a Pico W, RAM unchanged on each. The change only shows on the Zephyr backend, where the library build never saw the project flags.
