### PR TITLE
Cut the token buffer to the one pattern without name tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ off, since it builds its handshake from algorithm ids and never names one.
   must stay on, and `NOISE_USE_FALLBACK` must be off as well, since fallback
   needs the XX patterns named. The build stops with an `#error` if any of them
   says otherwise. `noise_handshakestate_new_by_id` likewise accepts only
-  `NNpsk0` in that build, and the pattern buffer in every handshake state
-  shrinks from 64 bytes to the 8 that pattern needs.
+  `NNpsk0` in that build, and with `NOISE_USE_HFS` off as well the pattern
+  buffer in every handshake state shrinks from 64 bytes to the 8 that
+  pattern needs.
 * `NOISE_USE_FALLBACK` and `NOISE_USE_HFS` keep the "fallback" and "hfs" pattern
   modifiers. With them off, a pattern that asks for one is rejected with
   `NOISE_ERROR_UNKNOWN_NAME`, and `noise_handshakestate_fallback` and

--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ off, since it builds its handshake from algorithm ids and never names one.
   must stay on, and `NOISE_USE_FALLBACK` must be off as well, since fallback
   needs the XX patterns named. The build stops with an `#error` if any of them
   says otherwise. `noise_handshakestate_new_by_id` likewise accepts only
-  `NNpsk0` in that build.
+  `NNpsk0` in that build, and the pattern buffer in every handshake state
+  shrinks from 64 bytes to the 8 that pattern needs.
 * `NOISE_USE_FALLBACK` and `NOISE_USE_HFS` keep the "fallback" and "hfs" pattern
   modifiers. With them off, a pattern that asks for one is rejected with
   `NOISE_ERROR_UNKNOWN_NAME`, and `noise_handshakestate_fallback` and

--- a/include/noise/defines.h
+++ b/include/noise/defines.h
@@ -86,6 +86,11 @@
 #define NOISE_USE_HFS 1
 #endif
 
+/* The build that can use one pattern only, NNpsk0: no name tables and no
+   hfs. Everything that sizes itself to that pattern tests this, not the
+   switches it is made of. */
+#define NOISE_SINGLE_PATTERN (!NOISE_USE_PROTOCOL_NAME_TABLE && !NOISE_USE_HFS)
+
 #if NOISE_USE_REFERENCE_BACKEND
 
 #ifndef NOISE_USE_REFERENCE_CHACHA

--- a/src/protocol/internal.h
+++ b/src/protocol/internal.h
@@ -57,14 +57,14 @@ extern "C" {
  * \brief Length in bytes of an expanded message pattern: two flag bytes,
  * the tokens and the end marker.
  *
- * Without the name tables and hfs the one pattern is NNpsk0, eight bytes,
- * so every handshake state and the stack buffer it is built from shrink to
- * that; hfs would add tokens NNpsk0 has no room for.
+ * In the single pattern build the one pattern is NNpsk0, eight bytes, so
+ * every handshake state and the stack buffer it is built from shrink to
+ * that.
  */
-#if NOISE_USE_PROTOCOL_NAME_TABLE || NOISE_USE_HFS
-#define NOISE_MAX_TOKENS 64
-#else
+#if NOISE_SINGLE_PATTERN
 #define NOISE_MAX_TOKENS 8
+#else
+#define NOISE_MAX_TOKENS 64
 #endif
 
 /**

--- a/src/protocol/internal.h
+++ b/src/protocol/internal.h
@@ -55,8 +55,16 @@ extern "C" {
 
 /**
  * \brief Maximum number of tokens in a message pattern.
+ *
+ * Two flag bytes, the tokens and the end marker. Without the name tables
+ * the one pattern is NNpsk0, eight bytes, so every handshake state and the
+ * stack buffer it is built from shrink to that.
  */
+#if NOISE_USE_PROTOCOL_NAME_TABLE
 #define NOISE_MAX_TOKENS 64
+#else
+#define NOISE_MAX_TOKENS 8
+#endif
 
 /**
  * \brief Internal structure of the NoiseCipherState type.

--- a/src/protocol/internal.h
+++ b/src/protocol/internal.h
@@ -54,13 +54,14 @@ extern "C" {
 #define NOISE_PSK_LEN 32
 
 /**
- * \brief Maximum number of tokens in a message pattern.
+ * \brief Length in bytes of an expanded message pattern: two flag bytes,
+ * the tokens and the end marker.
  *
- * Two flag bytes, the tokens and the end marker. Without the name tables
- * the one pattern is NNpsk0, eight bytes, so every handshake state and the
- * stack buffer it is built from shrink to that.
+ * Without the name tables and hfs the one pattern is NNpsk0, eight bytes,
+ * so every handshake state and the stack buffer it is built from shrink to
+ * that; hfs would add tokens NNpsk0 has no room for.
  */
-#if NOISE_USE_PROTOCOL_NAME_TABLE
+#if NOISE_USE_PROTOCOL_NAME_TABLE || NOISE_USE_HFS
 #define NOISE_MAX_TOKENS 64
 #else
 #define NOISE_MAX_TOKENS 8

--- a/tests/unit/test-small-build.c
+++ b/tests/unit/test-small-build.c
@@ -52,6 +52,14 @@ void test_small_build(void)
                  NOISE_ROLE_INITIATOR),
             NOISE_ERROR_UNKNOWN_NAME);
     verify(state == NULL);
+    /* The token buffer is cut down to the one pattern, end marker included */
+    {
+        uint8_t pattern[NOISE_MAX_TOKENS];
+        int modifier = NOISE_MODIFIER_PSK0;
+        compare(noise_pattern_expand(pattern, NOISE_PATTERN_NN, &modifier, 1),
+                NOISE_ERROR_NONE);
+        compare(pattern[NOISE_MAX_TOKENS - 1], NOISE_TOKEN_END);
+    }
     id.pattern_id = NOISE_PATTERN_XX;
     id.modifier_ids[0] = NOISE_MODIFIER_NONE;
     state = (NoiseHandshakeState *)8;

--- a/tests/unit/test-small-build.c
+++ b/tests/unit/test-small-build.c
@@ -52,6 +52,7 @@ void test_small_build(void)
                  NOISE_ROLE_INITIATOR),
             NOISE_ERROR_UNKNOWN_NAME);
     verify(state == NULL);
+#if NOISE_SINGLE_PATTERN
     /* The token buffer is cut down to the one pattern, end marker included */
     {
         uint8_t pattern[NOISE_MAX_TOKENS];
@@ -60,6 +61,7 @@ void test_small_build(void)
                 NOISE_ERROR_NONE);
         compare(pattern[NOISE_MAX_TOKENS - 1], NOISE_TOKEN_END);
     }
+#endif
     id.pattern_id = NOISE_PATTERN_XX;
     id.modifier_ids[0] = NOISE_MODIFIER_NONE;
     state = (NoiseHandshakeState *)8;


### PR DESCRIPTION
Follow up to #34. Without the name tables the only pattern is NNpsk0, eight bytes with the flags and the end marker, but `NOISE_MAX_TOKENS` stayed at 64: every handshake state carried a 64 byte pattern buffer on the heap, the constructor built one on the stack and copied all of it. The limit is now 8 in that build, so each handshake state is 56 bytes smaller on the heap and the constructor uses 56 bytes less stack; a full build keeps 64.

The small build test checks the expansion fills the buffer to the end marker, so a pattern that no longer fits would fail there rather than be cut short.

ESP8266 (xtensa gcc 10.3, -Os, the three switches off), handshakestate.c alone: 4369 to 4202 bytes of text, the constructor 630 to 585; plus the 56 bytes of heap per handshake state and 56 of stack while it is built.

| | ESP8266 before | ESP8266 after | AtomU before | AtomU after | Pico W before | Pico W after |
| --- | --- | --- | --- | --- | --- | --- |
| image flash | 393831 B | 393639 B | 744983 B | 744847 B | 487388 B | 487340 B |
| image RAM, static | 32172 B | 32172 B | 46720 B | 46720 B | 81036 B | 81036 B |
| heap per handshake state | 64 B of pattern | 8 B | 64 B | 8 B | 64 B | 8 B |
| handshake state new and free | 233 us | 226 us | 246 us | 236 us | 229 us | 209 us |
| handshake, min of 5 | 316, 312 ms | 310, 312 ms | 49.1, 49.2 ms | 49.4, 49.4 ms | 228, 229 ms | 223, 223 ms |

Each board ran the bench in one boot per build: ESPHome dev with noise-c 0.1.27 and the size switches off, the libsodium release from the registry, and this branch injected in place of the noise-c release. Handshake times are the minimum of five, two boots each; the ESP8266 and Pico W move by several milliseconds between boots from WiFi and the AtomU's state creation time varies with its heap, so those lines are direction only.
