### PR TITLE
Skip the modifier scan in the build without name tables

### DIFF
--- a/src/protocol/handshakestate.c
+++ b/src/protocol/handshakestate.c
@@ -117,6 +117,7 @@ static int noise_handshakestate_new
     int remote_dh_role;
 
     /* Locate the information for the current handshake pattern */
+#if NOISE_USE_PROTOCOL_NAME_TABLE
     num_modifiers = 0;
     while (num_modifiers < NOISE_MAX_MODIFIER_IDS &&
                 symmetric->id.modifier_ids[num_modifiers] != 0) {
@@ -132,6 +133,12 @@ static int noise_handshakestate_new
         }
         ++num_modifiers;
     }
+#else
+    /* The one pattern this build expands has exactly one modifier, psk0,
+       which noise_pattern_expand checks; a second one makes the id unknown */
+    num_modifiers = symmetric->id.modifier_ids[1] == NOISE_MODIFIER_NONE ? 1 : 2;
+    extra_reqs = NOISE_REQ_PSK;
+#endif
     if (noise_pattern_expand(tokens, symmetric->id.pattern_id,
                              symmetric->id.modifier_ids, num_modifiers)
             != NOISE_ERROR_NONE) {

--- a/tests/unit/test-small-build.c
+++ b/tests/unit/test-small-build.c
@@ -60,13 +60,17 @@ void test_small_build(void)
     verify(state == NULL);
     id.modifier_ids[0] = NOISE_MODIFIER_PSK1;
     id.modifier_ids[1] = NOISE_MODIFIER_NONE;
+    state = (NoiseHandshakeState *)8;
     compare(noise_handshakestate_new_by_id
                 (&state, &id, NOISE_ROLE_INITIATOR),
             NOISE_ERROR_UNKNOWN_ID);
+    verify(state == NULL);
     id.modifier_ids[0] = NOISE_MODIFIER_NONE;
+    state = (NoiseHandshakeState *)8;
     compare(noise_handshakestate_new_by_id
                 (&state, &id, NOISE_ROLE_INITIATOR),
             NOISE_ERROR_UNKNOWN_ID);
+    verify(state == NULL);
     id.pattern_id = NOISE_PATTERN_XX;
     id.modifier_ids[0] = NOISE_MODIFIER_NONE;
     state = (NoiseHandshakeState *)8;

--- a/tests/unit/test-small-build.c
+++ b/tests/unit/test-small-build.c
@@ -52,6 +52,21 @@ void test_small_build(void)
                  NOISE_ROLE_INITIATOR),
             NOISE_ERROR_UNKNOWN_NAME);
     verify(state == NULL);
+    id.modifier_ids[1] = NOISE_MODIFIER_PSK1;
+    state = (NoiseHandshakeState *)8;
+    compare(noise_handshakestate_new_by_id
+                (&state, &id, NOISE_ROLE_INITIATOR),
+            NOISE_ERROR_UNKNOWN_ID);
+    verify(state == NULL);
+    id.modifier_ids[0] = NOISE_MODIFIER_PSK1;
+    id.modifier_ids[1] = NOISE_MODIFIER_NONE;
+    compare(noise_handshakestate_new_by_id
+                (&state, &id, NOISE_ROLE_INITIATOR),
+            NOISE_ERROR_UNKNOWN_ID);
+    id.modifier_ids[0] = NOISE_MODIFIER_NONE;
+    compare(noise_handshakestate_new_by_id
+                (&state, &id, NOISE_ROLE_INITIATOR),
+            NOISE_ERROR_UNKNOWN_ID);
     id.pattern_id = NOISE_PATTERN_XX;
     id.modifier_ids[0] = NOISE_MODIFIER_NONE;
     state = (NoiseHandshakeState *)8;

--- a/tests/unit/test-small-build.c
+++ b/tests/unit/test-small-build.c
@@ -71,6 +71,19 @@ void test_small_build(void)
                 (&state, &id, NOISE_ROLE_INITIATOR),
             NOISE_ERROR_UNKNOWN_ID);
     verify(state == NULL);
+    /* Those ids are refused one layer up, in names-single.c; the expander
+       is what holds the modifier count to one for the constructor */
+    {
+        uint8_t pattern[NOISE_MAX_TOKENS];
+        int mods[2] = { NOISE_MODIFIER_PSK0, NOISE_MODIFIER_PSK1 };
+        compare(noise_pattern_expand(pattern, NOISE_PATTERN_NN, mods, 2),
+                NOISE_ERROR_UNKNOWN_NAME);
+        compare(noise_pattern_expand(pattern, NOISE_PATTERN_NN, mods, 0),
+                NOISE_ERROR_UNKNOWN_NAME);
+        compare(noise_pattern_expand(pattern, NOISE_PATTERN_NN, mods, 1),
+                NOISE_ERROR_NONE);
+    }
+
     id.pattern_id = NOISE_PATTERN_XX;
     id.modifier_ids[0] = NOISE_MODIFIER_NONE;
     state = (NoiseHandshakeState *)8;


### PR DESCRIPTION
Follow up to #39, on top of that branch. In the build without name tables `noise_pattern_expand` accepts exactly NN with psk0, so the constructor's walk over the modifier list to count modifiers and derive the psk requirement always ends the same way. It now passes one modifier when the second slot is empty and two otherwise, so a second modifier still makes the id unknown, and sets the psk requirement directly. The full build keeps the scan.

The small build test checks that psk0 with psk1, psk1 alone and no modifier are refused by id, which happens one layer up in names-single.c, and that the expander itself refuses two modifiers and none, which is what holds the constructor's count to one.

ESP8266 (xtensa gcc 10.3, -Os, the three switches off), handshakestate.c alone against #39: 4353 to 4328 bytes of text, the constructor 618 to 594.

Against #39 on the same three boards; the saving is the bytes, the bench sees nothing else:

| | ESP8266 #39 | ESP8266 this | AtomU #39 | AtomU this | Pico W #39 | Pico W this |
| --- | --- | --- | --- | --- | --- | --- |
| image flash | 393315 B | 393251 B | 744355 B | 744319 B | 486932 B | 486900 B |
| image RAM | 31976 B | 31976 B | 46720 B | 46720 B | 81036 B | 81036 B |
| handshake state new and free | 224 us | 227 us | 250 us | 275 us | 209 us | 207 us |
| handshake, min of 5 | 303, 304 ms | 312, 316 ms | 49.2, 49.4 ms | 49.4, 49.4 ms | 225, 229 ms | 221, 224 ms |

Each board ran the bench in one boot per build: ESPHome dev with noise-c 0.1.27 and the size switches off, the libsodium release from the registry, and this branch injected in place of the noise-c release. Handshake times are the minimum of five, two boots each; the ESP8266 and Pico W move by several milliseconds between boots from WiFi and the AtomU's state creation time varies with its heap, so those lines are direction only.
