### PR TITLE
Start a SymmetricState from the constant digest of the one protocol name

### DIFF
--- a/src/protocol/internal.h
+++ b/src/protocol/internal.h
@@ -715,6 +715,12 @@ static inline NoisePatternFlags_t noise_pattern_reverse_flags(NoisePatternFlags_
 {
     return ((flags >> 8) & 0x00FF) | ((flags << 8) & 0xFF00);
 }
+#if !NOISE_USE_PROTOCOL_NAME_TABLE
+/* The one protocol a build without name tables speaks, names-single.c */
+int noise_single_protocol_check(const NoiseProtocolId *id);
+void noise_single_protocol_init_hash(uint8_t *h);
+#endif
+
 int noise_pattern_expand
     (uint8_t pattern[NOISE_MAX_TOKENS], int pattern_id,
      const int *modifiers, size_t num_modifiers);

--- a/src/protocol/names-single.c
+++ b/src/protocol/names-single.c
@@ -74,6 +74,47 @@
 static const char noise_single_protocol_name[] NOISE_NAME_IN_FLASH =
     "Noise_NNpsk0_25519_ChaChaPoly_SHA256";
 
+/* SHA256 of the name above. The name is longer than the hash, so a
+   SymmetricState starts from its digest; keeping the digest saves the
+   hash and, for a build that only ever names the protocol by id, the
+   name and its formatter as well. test-single-protocol.c checks it. */
+static const uint8_t noise_single_protocol_hash[32] NOISE_NAME_IN_FLASH = {
+    0xf0, 0xb8, 0x90, 0x82, 0x6f, 0xb8, 0xe6, 0x58,
+    0x4a, 0xf6, 0x94, 0x8d, 0x22, 0x71, 0x69, 0xc3,
+    0x81, 0xc9, 0xed, 0x6a, 0x4c, 0x1c, 0x90, 0xdf,
+    0x4b, 0x9f, 0xf4, 0x54, 0xfa, 0x94, 0x7f, 0x7b
+};
+
+void noise_single_protocol_init_hash(uint8_t *h)
+{
+    noise_name_copy(h, noise_single_protocol_hash,
+                    sizeof(noise_single_protocol_hash));
+}
+
+int noise_single_protocol_check(const NoiseProtocolId *id)
+{
+    size_t slot;
+
+    if (id->prefix_id != NOISE_PREFIX_STANDARD ||
+            id->pattern_id != NOISE_PATTERN_NN ||
+            id->modifier_ids[0] != NOISE_MODIFIER_PSK0 ||
+            id->dh_id != NOISE_DH_CURVE25519 ||
+            id->cipher_id != NOISE_CIPHER_CHACHAPOLY ||
+            id->hash_id != NOISE_HASH_SHA256 ||
+            id->hybrid_id != NOISE_DH_NONE)
+        return NOISE_ERROR_UNKNOWN_ID;
+    /* psk0 is the only modifier; every other slot must be empty */
+    for (slot = 1; slot < NOISE_MAX_MODIFIER_IDS; ++slot) {
+        if (id->modifier_ids[slot] != NOISE_MODIFIER_NONE)
+            return NOISE_ERROR_UNKNOWN_ID;
+    }
+    for (slot = 0; slot < sizeof(id->reserved) / sizeof(id->reserved[0]); ++slot) {
+        if (id->reserved[slot])
+            return NOISE_ERROR_UNKNOWN_ID;
+    }
+    return NOISE_ERROR_NONE;
+}
+
 int noise_protocol_name_to_id
     (NoiseProtocolId *id, const char *name, size_t name_len)
 {
@@ -95,8 +136,6 @@ int noise_protocol_name_to_id
 int noise_protocol_id_to_name
     (char *name, size_t name_len, const NoiseProtocolId *id)
 {
-    size_t slot;
-
     if (!id) {
         if (name && name_len)
             *name = '\0';
@@ -109,28 +148,9 @@ int noise_protocol_id_to_name
             *name = '\0';
         return NOISE_ERROR_INVALID_LENGTH;
     }
-    if (id->prefix_id != NOISE_PREFIX_STANDARD ||
-            id->pattern_id != NOISE_PATTERN_NN ||
-            id->modifier_ids[0] != NOISE_MODIFIER_PSK0 ||
-            id->dh_id != NOISE_DH_CURVE25519 ||
-            id->cipher_id != NOISE_CIPHER_CHACHAPOLY ||
-            id->hash_id != NOISE_HASH_SHA256 ||
-            id->hybrid_id != NOISE_DH_NONE) {
+    if (noise_single_protocol_check(id) != NOISE_ERROR_NONE) {
         *name = '\0';
         return NOISE_ERROR_UNKNOWN_ID;
-    }
-    /* psk0 is the only modifier; every other slot must be empty */
-    for (slot = 1; slot < NOISE_MAX_MODIFIER_IDS; ++slot) {
-        if (id->modifier_ids[slot] != NOISE_MODIFIER_NONE) {
-            *name = '\0';
-            return NOISE_ERROR_UNKNOWN_ID;
-        }
-    }
-    for (slot = 0; slot < sizeof(id->reserved) / sizeof(id->reserved[0]); ++slot) {
-        if (id->reserved[slot]) {
-            *name = '\0';
-            return NOISE_ERROR_UNKNOWN_ID;
-        }
     }
     noise_name_copy(name, noise_single_protocol_name,
                     sizeof(noise_single_protocol_name));

--- a/src/protocol/symmetricstate.c
+++ b/src/protocol/symmetricstate.c
@@ -96,6 +96,16 @@ static int noise_symmetricstate_new
 
     /* Initialize the chaining key "ck" and the handshake hash "h" from
        the protocol name.  If the name is too long, hash it down first */
+#if !NOISE_USE_PROTOCOL_NAME_TABLE
+    if (!name) {
+        /* the one protocol this build speaks; its name is longer than the
+           hash, so the state starts from the digest kept in names-single.c */
+        noise_single_protocol_init_hash(new_state->h);
+        memcpy(new_state->ck, new_state->h, hash_len);
+        *state = new_state;
+        return NOISE_ERROR_NONE;
+    }
+#endif
     name_len = strlen(name);
     if (name_len <= hash_len) {
         memcpy(new_state->h, name, name_len);
@@ -134,7 +144,9 @@ static int noise_symmetricstate_new
 int noise_symmetricstate_new_by_id
     (NoiseSymmetricState **state, const NoiseProtocolId *id)
 {
+#if NOISE_USE_PROTOCOL_NAME_TABLE
     char name[NOISE_MAX_PROTOCOL_NAME];
+#endif
     int err;
 
     /* Validate the parameters */
@@ -144,6 +156,13 @@ int noise_symmetricstate_new_by_id
     if (!id)
         return NOISE_ERROR_INVALID_PARAM;
 
+#if !NOISE_USE_PROTOCOL_NAME_TABLE
+    /* No name to format: the state starts from the constant digest */
+    err = noise_single_protocol_check(id);
+    if (err != NOISE_ERROR_NONE)
+        return err;
+    return noise_symmetricstate_new(state, 0, id);
+#else
     /* Format the full protocol name from the identifiers.  We need the
        full name because the handshake hash is initialized from the name */
     err = noise_protocol_id_to_name(name, sizeof(name), id);
@@ -152,6 +171,7 @@ int noise_symmetricstate_new_by_id
 
     /* Create the SymmetricState object */
     return noise_symmetricstate_new(state, name, id);
+#endif
 }
 
 /**

--- a/tests/unit/test-single-protocol.c
+++ b/tests/unit/test-single-protocol.c
@@ -35,6 +35,8 @@
 #define noise_protocol_id_to_name single_id_to_name
 #define noise_protocol_name_to_id single_name_to_id
 #define noise_pattern_expand single_pattern_expand
+#define noise_single_protocol_check single_protocol_check
+#define noise_single_protocol_init_hash single_protocol_init_hash
 #include "protocol/names-single.c"
 #include "protocol/patterns-single.c"
 #undef noise_protocol_id_to_name
@@ -106,6 +108,24 @@ void test_single_protocol(void)
     id.hash_id = NOISE_HASH_SHA256;
     compare_id_to_name(&id);
     compare(single_id_to_name(name, sizeof(name), &id), NOISE_ERROR_NONE);
+
+    /* The digest the reduced build starts a SymmetricState from must be
+       the SHA256 of the name, which is what the full build hashes */
+    {
+        NoiseHashState *hash = 0;
+        uint8_t digest[32];
+        uint8_t stored[32];
+        compare(noise_hashstate_new_by_id(&hash, NOISE_HASH_SHA256),
+                NOISE_ERROR_NONE);
+        compare(noise_hashstate_hash_one
+                    (hash, (const uint8_t *)name, strlen(name),
+                     digest, sizeof(digest)),
+                NOISE_ERROR_NONE);
+        single_protocol_init_hash(stored);
+        compare_blocks(stored, sizeof(stored), digest, sizeof(digest));
+        compare(single_protocol_check(&id), NOISE_ERROR_NONE);
+        noise_hashstate_free(hash);
+    }
     verify(!strcmp(name, "Noise_NNpsk0_25519_ChaChaPoly_SHA256"));
     compare_name_to_id("Noise_NNpsk0_25519_ChaChaPoly_SHA256");
 

--- a/tests/unit/test-small-build.c
+++ b/tests/unit/test-small-build.c
@@ -45,6 +45,51 @@ void test_small_build(void)
             NOISE_ERROR_NONE);
     compare(noise_handshakestate_free(state), NOISE_ERROR_NONE);
 
+    /* A state made by id starts from the constant digest, one made by name
+       from hashing the name; the two must complete a handshake together */
+    {
+        static const uint8_t psk[32] = { 1, 2, 3 };
+        NoiseHandshakeState *initiator = 0;
+        NoiseHandshakeState *responder = 0;
+        uint8_t message[128];
+        uint8_t hash_i[32];
+        uint8_t hash_r[32];
+        NoiseBuffer buffer;
+        compare(noise_handshakestate_new_by_name
+                    (&initiator, single, NOISE_ROLE_INITIATOR),
+                NOISE_ERROR_NONE);
+        compare(noise_handshakestate_new_by_id
+                    (&responder, &id, NOISE_ROLE_RESPONDER),
+                NOISE_ERROR_NONE);
+        compare(noise_handshakestate_set_pre_shared_key(initiator, psk, 32),
+                NOISE_ERROR_NONE);
+        compare(noise_handshakestate_set_pre_shared_key(responder, psk, 32),
+                NOISE_ERROR_NONE);
+        compare(noise_handshakestate_start(initiator), NOISE_ERROR_NONE);
+        compare(noise_handshakestate_start(responder), NOISE_ERROR_NONE);
+        noise_buffer_set_output(buffer, message, sizeof(message));
+        compare(noise_handshakestate_write_message(initiator, &buffer, 0),
+                NOISE_ERROR_NONE);
+        noise_buffer_set_input(buffer, message, buffer.size);
+        compare(noise_handshakestate_read_message(responder, &buffer, 0),
+                NOISE_ERROR_NONE);
+        noise_buffer_set_output(buffer, message, sizeof(message));
+        compare(noise_handshakestate_write_message(responder, &buffer, 0),
+                NOISE_ERROR_NONE);
+        noise_buffer_set_input(buffer, message, buffer.size);
+        compare(noise_handshakestate_read_message(initiator, &buffer, 0),
+                NOISE_ERROR_NONE);
+        compare(noise_handshakestate_get_action(initiator), NOISE_ACTION_SPLIT);
+        compare(noise_handshakestate_get_action(responder), NOISE_ACTION_SPLIT);
+        compare(noise_handshakestate_get_handshake_hash(initiator, hash_i, 32),
+                NOISE_ERROR_NONE);
+        compare(noise_handshakestate_get_handshake_hash(responder, hash_r, 32),
+                NOISE_ERROR_NONE);
+        compare_blocks(hash_i, 32, hash_r, 32);
+        compare(noise_handshakestate_free(initiator), NOISE_ERROR_NONE);
+        compare(noise_handshakestate_free(responder), NOISE_ERROR_NONE);
+    }
+
     /* Every other protocol is unknown, and the out parameter is cleared */
     state = (NoiseHandshakeState *)8;
     compare(noise_handshakestate_new_by_name


### PR DESCRIPTION
Without the name tables the protocol name is a constant, and it is longer than the hash, so every SymmetricState started by formatting the name and hashing it. The reduced build now keeps the SHA256 digest of the name next to the name in names-single.c and starts the state from that: `noise_symmetricstate_new_by_id` validates the id through a shared check and skips the formatter and the hash. The by name constructors still hash the name they are given, which gives the same digest; the small build test runs a handshake between a state made by name and one made by id and compares the handshake hashes, and the single protocol test checks the stored digest against SHA256 of the name.

Object level, the switches off: the code a build that names the protocol by id links goes 586 to 522 bytes on the ESP8266, 447 to 417 on the ESP32 and 481 to 433 on the RP2040; the formatter and the 37 byte name drop out, the id check and the 32 byte digest come in. One SHA256 of the name fewer per handshake state, which is the state creation column below.

| board | before flash | after flash | change | before RAM | after RAM | rodata |
| --- | --- | --- | --- | --- | --- | --- |
| ESP8266 d1 mini | 391207 B | 391191 B | -16 B | 31976 B | 31976 B | name (37 B, in flash) out, digest 32 B in |
| AtomU, ESP32 | 742267 B | 742279 B | +12 B | 46720 B | 46720 B | name 37 B out, digest 32 B in |
| Pico W, RP2040 | 484876 B | 484828 B | -48 B | 81036 B | 81036 B | name 37 B out, digest 32 B in |

| board | SHA256 per block, hot | 32 B hash after a scalar multiply | handshake state new and free | handshake, min of 5 |
| --- | --- | --- | --- | --- |
| ESP8266 d1 mini | 54.3 to 54.3 us | 144 to 154 us | 220 to 153 us | 310, 310 to 307, 309 ms |
| AtomU, ESP32 | 18.4 to 18.4 us | 175 to 174 us | 359 to 163 us | 48.5, 48.5 to 48.7, 48.3 ms |
| Pico W, RP2040 | 53.5 to 53.2 us | 195 to 199 us | 190 to 116 us | 220, 223 to 221, 222 ms |

Measured on the three boards with a bench firmware that hashes fixed inputs, hashes once right after a base point multiply, creates and frees handshake states, and runs five handshakes in memory taking the minimum; one boot per build, registry packages noise-c 0.1.28 and libsodium 1.10021.9 as the baseline with the branch injected in place of the library it changes. The cold hash and the AtomU state creation time swing between boots, and the ESP8266 and Pico W handshakes by several milliseconds, so those cells are direction only; the hot block, the flash and RAM lines and the AtomU handshake are stable.
