### PR TITLE
Depend on libsodium 1.10021.10

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -2,4 +2,4 @@ description: noise-c
 version: "0.1.28"
 repository: https://github.com/esphome/noise-c.git
 dependencies:
-  esphome/libsodium: "1.10021.9"
+  esphome/libsodium: "1.10021.10"

--- a/library.json
+++ b/library.json
@@ -25,7 +25,7 @@
         {
             "owner": "esphome",
             "name": "libsodium",
-            "version": "1.10021.9"
+            "version": "1.10021.10"
         }
     ]
 }


### PR DESCRIPTION
libsodium 1.10021.10 carries the three ESP8266 DRAM patches (esphome-libs/libsodium#42, #43, #44), so the library and component manifests pin it. The test build fetches the fork at the pinned tag, so CI runs the noise-c suite against the new libsodium as well.

ESPHome pins both libraries exactly and the ESP-IDF resolver refuses two pins that disagree, so its bump to 1.10021.10 goes together with the noise-c release that carries this.
